### PR TITLE
34 make some tests with shared ptr alternatives

### DIFF
--- a/aether/actions/action_trigger.h
+++ b/aether/actions/action_trigger.h
@@ -18,24 +18,21 @@
 #define AETHER_ACTIONS_ACTION_TRIGGER_H_
 
 #include <mutex>
-#include <memory>
 #include <atomic>
 #include <condition_variable>
 
 #include "aether/common.h"
+#include "aether/ptr/rc_ptr.h"
 
 namespace ae {
 struct SyncObject {
-  // TODO: is this cross-platform?
-  std::mutex mutex_;
-  std::condition_variable condition_;
-  std::atomic<bool> triggered_{false};
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::atomic<bool> triggered{false};
 };
 
 class ActionTrigger {
   friend void Merge(ActionTrigger& left, ActionTrigger& right);
-
-  std::shared_ptr<SyncObject> sync_object_;
 
  public:
   ActionTrigger();
@@ -48,6 +45,9 @@ class ActionTrigger {
 
   // call this by action if update required
   void Trigger();
+
+ private:
+  RcPtr<SyncObject> sync_object_;
 };
 
 // merge to action triggers in one

--- a/aether/common.h
+++ b/aether/common.h
@@ -108,4 +108,7 @@ enum class CompressionMethod : std::uint8_t {
 #define AE_REQUIRERS_NOT(Condition) \
   std::enable_if_t<!AE_DEPAREN(Condition)::value, int> = 0
 
+#define AE_REQUIRERS_BOOL(Condition) \
+  std::enable_if_t<AE_DEPAREN(Condition), int> = 0
+
 #endif  // AETHER_COMMON_H_

--- a/aether/events/event_subscription.cpp
+++ b/aether/events/event_subscription.cpp
@@ -21,7 +21,7 @@
 namespace ae {
 Subscription::Subscription() = default;
 
-Subscription::Subscription(std::shared_ptr<SubscriptionManage> subscription)
+Subscription::Subscription(RcPtr<SubscriptionManage> subscription)
     : subscription_{std::move(subscription)} {}
 
 Subscription::Subscription(Subscription&& other) noexcept
@@ -39,7 +39,7 @@ Subscription::operator bool() const {
   return subscription_ && subscription_->alive;
 }
 
-void Subscription::Reset() { subscription_.reset(); }
+void Subscription::Reset() { subscription_.Reset(); }
 
 Subscription Subscription::Once() && {
   assert(subscription_);

--- a/aether/events/event_subscription.h
+++ b/aether/events/event_subscription.h
@@ -17,10 +17,10 @@
 #ifndef AETHER_EVENTS_EVENT_SUBSCRIPTION_H_
 #define AETHER_EVENTS_EVENT_SUBSCRIPTION_H_
 
-#include <memory>
 #include <utility>
 
 #include "aether/common.h"
+#include "aether/ptr/rc_ptr.h"
 
 #include "aether/events/event_handler.h"
 
@@ -38,7 +38,7 @@ template <typename Signature>
 class EventHandlerSubscription {
  public:
   explicit EventHandlerSubscription(
-      std::shared_ptr<SubscriptionManage> const& subscription,
+      RcPtr<SubscriptionManage> const& subscription,
       EventHandler<Signature>&& handler)
       : handler_{std::move(handler)}, subscription_{subscription} {}
 
@@ -71,9 +71,8 @@ class EventHandlerSubscription {
   }
 
  private:
-  // IEventHandler used to reduce shared_ptr template instantiations
   EventHandler<Signature> handler_;
-  std::weak_ptr<SubscriptionManage> subscription_;
+  RcPtrView<SubscriptionManage> subscription_;
 };
 
 /**
@@ -86,7 +85,7 @@ class Subscription {
  public:
   Subscription();
 
-  explicit Subscription(std::shared_ptr<SubscriptionManage> subscription);
+  explicit Subscription(RcPtr<SubscriptionManage> subscription);
 
   Subscription(Subscription const&) = delete;
   Subscription(Subscription&& other) noexcept;
@@ -104,7 +103,7 @@ class Subscription {
   void Reset();
 
  private:
-  std::shared_ptr<SubscriptionManage> subscription_;
+  RcPtr<SubscriptionManage> subscription_;
 };
 
 }  // namespace ae

--- a/aether/ptr/rc_ptr.h
+++ b/aether/ptr/rc_ptr.h
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2024 Aethernet Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AETHER_PTR_RC_PTR_H_
+#define AETHER_PTR_RC_PTR_H_
+
+#include <memory>
+#include <cstdint>
+#include <cassert>
+#include <utility>
+
+#include "aether/ptr/storage.h"
+#include "aether/mstream.h"
+
+namespace ae {
+// for most cases 2*uint8_t should be more than enough
+// saving more space is impossible due to alignment in RcStorage
+struct RefCounters {
+  std::uint8_t main_refs;
+  std::uint8_t weak_refs;
+};
+
+template <typename T>
+class RcStorage {
+ public:
+  [[nodiscard]] RefCounters& ref_counters() noexcept { return ref_counters_; }
+  [[nodiscard]] RefCounters const& ref_counters() const noexcept {
+    return ref_counters_;
+  }
+  [[nodiscard]] auto* ptr() noexcept { return storage_.ptr(); }
+  [[nodiscard]] auto* ptr() const noexcept { return storage_.ptr(); }
+
+ private:
+  RefCounters ref_counters_;
+  Storage<T> storage_;
+};
+
+template <typename T>
+class RcPtr {
+  template <typename U>
+  friend class RcPtr;
+
+  template <typename U>
+  friend class RcPtrView;
+
+ public:
+  RcPtr() noexcept : rc_storage_{nullptr} {}
+  RcPtr(std::nullptr_t) noexcept : rc_storage_{nullptr} {}
+  explicit RcPtr(RcStorage<T>* rc_storage) noexcept : rc_storage_{rc_storage} {
+    if (rc_storage_ != nullptr) {
+      Increment();
+    }
+  }
+  ~RcPtr() { Reset(); }
+
+  // Copying
+  RcPtr(RcPtr const& other) noexcept : RcPtr{other.rc_storage_} {}
+
+  auto& operator=(RcPtr const& other) noexcept {
+    if (this != &other) {
+      Reset();
+      rc_storage_ = other.rc_storage_;
+      if (rc_storage_ != nullptr) {
+        Increment();
+      }
+    }
+    return *this;
+  }
+
+  // Moving
+  RcPtr(RcPtr&& other) noexcept : rc_storage_{other.rc_storage_} {
+    other.rc_storage_ = nullptr;
+  }
+
+  auto& operator=(RcPtr&& other) noexcept {
+    if (this != &other) {
+      Reset();
+      std::swap(rc_storage_, other.rc_storage_);
+    }
+    return *this;
+  }
+
+  // Access
+  [[nodiscard]] T* get() {
+    return (rc_storage_ != nullptr) ? rc_storage_->ptr() : nullptr;
+  }
+  [[nodiscard]] T* get() const {
+    return (rc_storage_ != nullptr) ? rc_storage_->ptr() : nullptr;
+  }
+
+  [[nodiscard]] T* operator->() noexcept { return get(); }
+  [[nodiscard]] T* operator->() const noexcept { return get(); }
+  [[nodiscard]] T& operator*() noexcept { return *get(); }
+  [[nodiscard]] T& operator*() const noexcept { return *get(); }
+
+  explicit operator bool() const { return rc_storage_ != nullptr; }
+
+  // Modifying
+  void Reset() {
+    if (rc_storage_ == nullptr) {
+      return;
+    }
+
+    Decrement();
+    if (rc_storage_->ref_counters().main_refs == 0) {
+      // Call destructor on T
+      rc_storage_->ptr()->~T();
+
+      if (rc_storage_->ref_counters().weak_refs == 0) {
+        auto alloc = std::allocator<RcStorage<T>>{};
+        alloc.deallocate(rc_storage_, std::size_t{1});
+      }
+    }
+    rc_storage_ = nullptr;
+  }
+
+ private:
+  void Decrement() noexcept { rc_storage_->ref_counters().main_refs -= 1; }
+  void Increment() noexcept { rc_storage_->ref_counters().main_refs += 1; }
+
+  RcStorage<T>* rc_storage_;
+};
+
+/**
+ * \brief Construct an RcPtr
+ */
+template <typename T, typename... TArgs>
+auto MakeRcPtr(TArgs&&... args) noexcept {
+  auto alloc = std::allocator<RcStorage<T>>{};
+  auto* rc_storage = alloc.allocate(std::size_t{1});
+  assert(rc_storage != nullptr);
+  auto* constructed = new (rc_storage->ptr()) T(std::forward<TArgs>(args)...);
+  if (!constructed) {
+    alloc.deallocate(rc_storage, std::size_t{1});
+    return RcPtr<T>{};
+  }
+  rc_storage->ref_counters() = {};
+  return RcPtr<T>{rc_storage};
+}
+
+template <template <typename...> typename T, typename... TArgs>
+auto MakeRcPtr(TArgs&&... args) noexcept {
+  using DeducedT = decltype(T{std::forward<TArgs>(args)...});
+  return MakeRcPtr<DeducedT>(std::forward<TArgs>(args)...);
+}
+
+template <typename T>
+class RcPtrView {
+  template <typename U>
+  friend class RcPtrView;
+
+  using OurRcPtr = RcPtr<T>;
+
+ public:
+  RcPtrView() noexcept : rc_storage_{nullptr} {}
+  ~RcPtrView() noexcept { Reset(); }
+
+  RcPtrView(OurRcPtr const& rpc_ptr) noexcept
+      : RcPtrView{rpc_ptr.rc_storage_} {}
+
+  // Copying
+  RcPtrView(RcPtrView const& other) noexcept : RcPtrView{other.rc_storage_} {}
+
+  RcPtrView& operator=(RcPtrView const& other) noexcept {
+    if (this != &other) {
+      Reset();
+      rc_storage_ = other.rc_storage_;
+      if (rc_storage_ != nullptr) {
+        Increment();
+      }
+    }
+    return *this;
+  }
+
+  // Moving
+  RcPtrView(RcPtrView&& other) noexcept : rc_storage_{other.rc_storage_} {
+    other.rc_storage_ = nullptr;
+  }
+
+  RcPtrView& operator=(RcPtrView&& other) noexcept {
+    if (this != &other) {
+      Reset();
+      std::swap(rc_storage_, other.rc_storage_);
+    }
+    return *this;
+  }
+
+  // Access
+  OurRcPtr lock() noexcept {
+    if (rc_storage_ != nullptr) {
+      if (rc_storage_->ref_counters().main_refs != 0) {
+        return OurRcPtr{rc_storage_};
+      }
+    }
+    return OurRcPtr{};
+  }
+
+  OurRcPtr lock() const noexcept {
+    if (rc_storage_ != nullptr) {
+      if (rc_storage_->ref_counters().main_refs != 0) {
+        return OurRcPtr{rc_storage_};
+      }
+    }
+    return OurRcPtr{};
+  }
+
+  explicit operator bool() const noexcept {
+    return (rc_storage_ != nullptr) &&
+           (rc_storage_->ref_counters().main_refs != 0);
+  }
+
+  // Modifying
+  void Reset() noexcept {
+    if (rc_storage_ == nullptr) {
+      return;
+    }
+
+    Decrement();
+    if ((rc_storage_->ref_counters().main_refs == 0) &&
+        (rc_storage_->ref_counters().weak_refs == 0)) {
+      auto alloc = std::allocator<RcStorage<T>>{};
+      alloc.deallocate(rc_storage_, std::size_t{1});
+    }
+    rc_storage_ = nullptr;
+  }
+
+ private:
+  explicit RcPtrView(RcStorage<T>* rc_storage) noexcept
+      : rc_storage_{rc_storage} {
+    if (rc_storage_ == nullptr) {
+      return;
+    }
+    Increment();
+  }
+
+  void Decrement() noexcept { rc_storage_->ref_counters().weak_refs -= 1; }
+  void Increment() noexcept { rc_storage_->ref_counters().weak_refs += 1; }
+
+  RcStorage<T>* rc_storage_;
+};
+
+template <typename T, typename Ob>
+omstream<Ob>& operator<<(omstream<Ob>& s, RcPtr<T> const& v) {
+  if (v) {
+    s << true;
+    s << *v;
+  } else {
+    s << false;
+  }
+  return s;
+}
+
+template <typename T, typename Ib>
+imstream<Ib>& operator>>(imstream<Ib>& s, RcPtr<T>& v) {
+  bool has_value{};
+  s >> has_value;
+  if (!data_was_read(s)) {
+    return s;
+  }
+  if (has_value) {
+    auto temp = MakeRcPtr<T>();
+    s >> *temp;
+    if (data_was_read(s)) {
+      v = std::move(temp);
+    }
+  }
+  return s;
+}
+
+}  // namespace ae
+
+#endif  // AETHER_PTR_RC_PTR_H_

--- a/aether/ptr/storage.h
+++ b/aether/ptr/storage.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Aethernet Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AETHER_PTR_STORAGE_H_
+#define AETHER_PTR_STORAGE_H_
+
+#include <new>
+#include <cstdint>
+
+#include "aether/common.h"
+
+namespace ae {
+template <typename T>
+class Storage {
+ public:
+  Storage() noexcept = default;
+
+  AE_CLASS_NO_COPY_MOVE(Storage);
+
+  [[nodiscard]] T const* ptr() const noexcept {
+    return std::launder(reinterpret_cast<T const*>(data_));
+  }
+  [[nodiscard]] T* ptr() noexcept {
+    return std::launder(reinterpret_cast<T*>(data_));
+  }
+
+ private:
+  alignas(alignof(T)) std::uint8_t data_[sizeof(T)];
+};
+}  // namespace ae
+
+#endif  // AETHER_PTR_STORAGE_H_

--- a/aether/tele/traps/statistics_trap.h
+++ b/aether/tele/traps/statistics_trap.h
@@ -30,6 +30,7 @@
 #include "aether/mstream.h"
 #include "aether/mstream_buffers.h"
 #include "aether/packed_int.h"
+#include "aether/ptr/rc_ptr.h"
 
 #include "aether/config.h"
 
@@ -160,7 +161,7 @@ class Statistics {
 template <typename T>
 class ProxyStatistics {
  public:
-  ProxyStatistics(std::shared_ptr<Statistics> statistics, T& data) noexcept;
+  ProxyStatistics(RcPtr<Statistics> statistics, T& data) noexcept;
   ProxyStatistics(ProxyStatistics const& other) = delete;
   ProxyStatistics(ProxyStatistics&& other) noexcept;
   ~ProxyStatistics() noexcept;
@@ -168,7 +169,7 @@ class ProxyStatistics {
   T* operator->() noexcept;
 
  private:
-  std::shared_ptr<Statistics> statistics_;
+  RcPtr<Statistics> statistics_;
   T* data_{};
   typename T::size_type size_{};
 };
@@ -193,7 +194,7 @@ class StatisticsStore {
    * If current statistics is full, move it into previous and return new
    * current.
    */
-  std::shared_ptr<Statistics> Get();
+  RcPtr<Statistics> Get();
 
   EnvStore& GetEnvStore();
 
@@ -216,8 +217,8 @@ class StatisticsStore {
 
   std::size_t statistics_size_limit_{kMaxSize};
   EnvStore env_store_;
-  std::shared_ptr<Statistics> prev_;
-  std::shared_ptr<Statistics> current_;
+  RcPtr<Statistics> prev_;
+  RcPtr<Statistics> current_;
 };
 
 /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,5 +48,6 @@ add_subdirectory(test-actions)
 add_subdirectory(test-events)
 add_subdirectory(test-transport)
 add_subdirectory(test-stream)
+add_subdirectory(test-ptr)
 
 add_subdirectory(third_party_tests)

--- a/tests/benchmarking.h
+++ b/tests/benchmarking.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Aethernet Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TESTS_BENCHMARKING_H_
+#define TESTS_BENCHMARKING_H_
+
+#include <chrono>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <string_view>
+
+namespace ae::tests {
+template <typename Func, typename... MessageArgs>
+void BenchmarkFunc(Func&& func, std::size_t count,
+                   MessageArgs&&... message_args) {
+  auto time_before = std::chrono::steady_clock::now();
+  for (volatile std::size_t i = 0; i < count; ++i) {
+    func(i);
+  }
+  auto time_after = std::chrono::steady_clock::now();
+  auto diff = std::chrono::duration_cast<std::chrono::duration<double>>(
+      time_after - time_before);
+
+  std::cout << "┌" << '\n' << "│Bench: ";
+  ((std::cout << message_args), ...);
+  std::cout << "\n│\tcount: " << count
+            << "\n│\tres time: " << std::setprecision(9) << std::fixed
+            << diff.count() << " sec."
+            << "\n└" << std::endl;
+}
+
+}  // namespace ae::tests
+
+#endif  // TESTS_BENCHMARKING_H_

--- a/tests/test-ptr/CMakeLists.txt
+++ b/tests/test-ptr/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright 2024 Aethernet Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required( VERSION 3.16 )
+
+option(AE_RC_PTR_BENCH "Make a benchmark for rc ptr compared to std::shared_ptr" Off)
+
+list(APPEND test_srcs
+    main.cpp
+    test-rc-ptr.cpp
+    test-rc-ptr-bench.cpp
+    test-shared-ptr-bench.cpp
+)
+
+if(NOT CM_PLATFORM)
+  project(test-ptr LANGUAGES CXX)
+
+  add_executable(${PROJECT_NAME})
+  target_sources(${PROJECT_NAME} PRIVATE ${test_srcs})
+  # for aether
+  target_include_directories(${PROJECT_NAME} PRIVATE ${ROOT_DIR})
+  target_link_libraries(${PROJECT_NAME} PRIVATE unity)
+
+  add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>)
+else()
+  message(WARNING "Not implemented for ${CM_PLATFORM}")
+endif()
+
+if (AE_RC_PTR_BENCH)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE "AE_RC_PTR_BENCH=1")
+endif()

--- a/tests/test-ptr/main.cpp
+++ b/tests/test-ptr/main.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Aethernet Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unity.h>
+
+void setUp() {}
+void tearDown() {}
+
+extern int test_rc_ptr();
+extern int test_rc_ptr_bench();
+extern int test_shared_ptr_bench();
+
+int main() {
+  int res = 0;
+
+  res += test_rc_ptr();
+
+#if defined AE_RC_PTR_BENCH
+  res += test_rc_ptr_bench();
+  res += test_shared_ptr_bench();
+#endif
+  return res;
+}

--- a/tests/test-ptr/pipe_there_they_are_sitting.h
+++ b/tests/test-ptr/pipe_there_they_are_sitting.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Aethernet Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TESTS_TEST_PTR_PIPE_THERE_THEY_ARE_SITTING_H_
+#define TESTS_TEST_PTR_PIPE_THERE_THEY_ARE_SITTING_H_
+
+namespace ae::test_ptr {
+struct A {
+  A() = default;
+  virtual ~A() { ++a_destroyed; }
+
+  static inline int a_destroyed = 0;
+  int x;
+};
+
+struct B : public A {
+  B() : A() {}
+  virtual ~B() { ++b_destroyed; }
+
+  static inline int b_destroyed = 0;
+  int y;
+};
+}  // namespace ae::test_ptr
+#endif  // TESTS_TEST_PTR_PIPE_THERE_THEY_ARE_SITTING_H_

--- a/tests/test-ptr/test-rc-ptr-bench.cpp
+++ b/tests/test-ptr/test-rc-ptr-bench.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Aethernet Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unity.h>
+
+#include <vector>
+
+#include "aether/ptr/rc_ptr.h"
+
+#include "tests/benchmarking.h"
+
+namespace ae::test_rc_ptr_bench {
+#if !defined NDEBUG
+static constexpr std::size_t kBenchCount = 10'000'000;
+#else
+static constexpr std::size_t kBenchCount = 100'000'000;
+#endif
+
+struct Rabbit {
+  Rabbit(int y) { x = y * y; }
+  ~Rabbit() { x = x - x / 2; }
+  volatile int x{0};
+};
+
+void test_rc_ptr_CreationBench() {
+  tests::BenchmarkFunc(
+      [](auto i) {
+        auto rabbit_ptr = MakeRcPtr<Rabbit>(i);
+        rabbit_ptr->x += static_cast<int>(i) % 100;
+        rabbit_ptr.Reset();
+      },
+      kBenchCount, "create and destroy ");
+
+  std::vector<RcPtr<Rabbit>> rabbits1;
+  rabbits1.reserve(1000);
+  tests::BenchmarkFunc(
+      [&](auto i) {
+        for (volatile auto j = 0; j < rabbits1.capacity(); j++) {
+          rabbits1.push_back(MakeRcPtr<Rabbit>(i + j));
+          rabbits1.back()->x += static_cast<int>(i) % 100;
+        }
+        rabbits1.clear();
+      },
+      kBenchCount / rabbits1.capacity(), "create a bunch size ",
+      rabbits1.capacity(), " and destroy all after");
+}
+
+std::vector<RcPtr<Rabbit>> rabbits2;
+void test_rc_ptr_CopyingBench() {
+  tests::BenchmarkFunc(
+      [&](auto i) {
+        rabbits2.push_back(MakeRcPtr<Rabbit>(i % 10'000));
+        if (((i + 1) % 10'000) == 0) {
+          rabbits2.clear();
+          rabbits2.shrink_to_fit();
+        }
+      },
+      kBenchCount, "moving inside the vector while it grows max ", 10'000,
+      " elements");
+
+  std::vector<RcPtr<Rabbit>> rabbits3;
+  rabbits3.reserve(1000);
+  for (volatile std::size_t j = 0; j < rabbits3.capacity(); j++) {
+    rabbits3.push_back(MakeRcPtr<Rabbit>(j));
+  }
+  tests::BenchmarkFunc(
+      [&](auto i) {
+        auto copy_rabbits = rabbits3;
+        for (auto& r : copy_rabbits) {
+          r->x += i % 100;
+        }
+      },
+      kBenchCount / 100, "copying the vector size: ", rabbits3.capacity());
+}
+
+}  // namespace ae::test_rc_ptr_bench
+
+int test_rc_ptr_bench() {
+  UNITY_BEGIN();
+  RUN_TEST(ae::test_rc_ptr_bench::test_rc_ptr_CreationBench);
+  RUN_TEST(ae::test_rc_ptr_bench::test_rc_ptr_CopyingBench);
+  return UNITY_END();
+}

--- a/tests/test-ptr/test-rc-ptr.cpp
+++ b/tests/test-ptr/test-rc-ptr.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2024 Aethernet Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unity.h>
+
+#include <vector>
+
+#include "aether/ptr/rc_ptr.h"
+
+#include "tests/test-ptr/pipe_there_they_are_sitting.h"
+
+namespace ae::test_rc_ptr {
+using test_ptr::A;
+using test_ptr::B;
+
+void test_createPtr() {
+  {
+    RcPtr<A> a;
+    RcPtr<A> a1{nullptr};
+  }
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    TEST_ASSERT(a);
+  }
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    RcPtr<A> a1{a};
+    TEST_ASSERT(a);
+    TEST_ASSERT(a1);
+  }
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    RcPtr<A> a1{std::move(a)};
+    TEST_ASSERT(!a);
+    TEST_ASSERT(a1);
+  }
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    RcPtr<A> a1{std::move(a)};
+    TEST_ASSERT(!a);
+    TEST_ASSERT(a1);
+  }
+}
+
+void test_ptrAssignment() {
+  A::a_destroyed = 0;
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    RcPtr<A> a1{};
+    a1 = a;
+    TEST_ASSERT(a);
+    TEST_ASSERT(a1);
+  }
+  TEST_ASSERT_EQUAL(1, A::a_destroyed);
+
+  A::a_destroyed = 0;
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    RcPtr<A> a1;
+    a1 = std::move(a);
+    TEST_ASSERT(!a);
+    TEST_ASSERT(a1);
+  }
+  TEST_ASSERT_EQUAL(1, A::a_destroyed);
+
+  A::a_destroyed = 0;
+  B::b_destroyed = 0;
+}
+
+void test_ptrAccess() {
+  A::a_destroyed = 0;
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    a->x = 1;
+    A& aref = *a;
+    aref.x = 2;
+    TEST_ASSERT(!!a);
+    TEST_ASSERT_EQUAL(a->x, (*a).x);
+  }
+  {
+    RcPtr<A> const a{MakeRcPtr<A>()};
+    a->x = 1;
+    A& aref = *a;
+    aref.x = 2;
+    TEST_ASSERT(!!a);
+    TEST_ASSERT_EQUAL(a->x, (*a).x);
+  }
+}
+
+void test_ptrLifeTime() {
+  A::a_destroyed = 0;
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    RcPtr<A> a1{MakeRcPtr<A>()};
+  }
+  TEST_ASSERT_EQUAL(2, A::a_destroyed);
+
+  A::a_destroyed = 0;
+  B::b_destroyed = 0;
+  {
+    // check if parent destructor is called too
+    RcPtr<B> b{MakeRcPtr<B>()};
+  }
+  TEST_ASSERT_EQUAL(1, A::a_destroyed);
+  TEST_ASSERT_EQUAL(1, B::b_destroyed);
+
+  A::a_destroyed = 0;
+  B::b_destroyed = 0;
+}
+
+void test_ptrView() {
+  {
+    RcPtrView<A> a_view{};
+    TEST_ASSERT(!a_view);
+  }
+  A::a_destroyed = 0;
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    RcPtrView<A> a_view{a};
+    TEST_ASSERT(!!a_view);
+    a.Reset();
+    TEST_ASSERT(!a_view);
+    TEST_ASSERT_EQUAL(1, A::a_destroyed);
+  }
+
+  A::a_destroyed = 0;
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    RcPtrView<A> a_view{a};
+    auto a1 = a_view.lock();
+    TEST_ASSERT(!!a1);
+    a.Reset();
+    TEST_ASSERT_EQUAL(0, A::a_destroyed);
+    a1.Reset();
+    TEST_ASSERT_EQUAL(1, A::a_destroyed);
+    auto a2 = a_view.lock();
+    TEST_ASSERT(!a2);
+  }
+
+  A::a_destroyed = 0;
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    std::vector<RcPtrView<A>> views;
+    for (std::size_t i = 0; i < 10; ++i) {
+      views.emplace_back(a);
+    }
+    for (auto& v : views) {
+      v.Reset();
+    }
+    TEST_ASSERT_EQUAL(0, A::a_destroyed);
+    a.Reset();
+    TEST_ASSERT_EQUAL(1, A::a_destroyed);
+  }
+  {
+    RcPtr<A> a{MakeRcPtr<A>()};
+    RcPtrView<A> a_view;
+    TEST_ASSERT(!a_view);
+    a_view = a;
+    TEST_ASSERT(!!a_view);
+    RcPtrView<A> a_view1{std::move(a_view)};
+    TEST_ASSERT(!a_view);
+    TEST_ASSERT(!!a_view1);
+    RcPtrView<A> a_view2;
+    TEST_ASSERT(!a_view2);
+    a_view2 = std::move(a_view1);
+    TEST_ASSERT(!a_view1);
+    TEST_ASSERT(!!a_view2);
+  }
+}
+
+}  // namespace ae::test_rc_ptr
+
+int test_rc_ptr() {
+  UNITY_BEGIN();
+  RUN_TEST(ae::test_rc_ptr::test_createPtr);
+  RUN_TEST(ae::test_rc_ptr::test_ptrAssignment);
+  RUN_TEST(ae::test_rc_ptr::test_ptrAccess);
+  RUN_TEST(ae::test_rc_ptr::test_ptrLifeTime);
+  RUN_TEST(ae::test_rc_ptr::test_ptrView);
+  return UNITY_END();
+}

--- a/tests/test-ptr/test-shared-ptr-bench.cpp
+++ b/tests/test-ptr/test-shared-ptr-bench.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Aethernet Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unity.h>
+
+#include <vector>
+#include <memory>
+
+#include "tests/benchmarking.h"
+
+namespace ae::test_shared_ptr_bench {
+#if !defined NDEBUG
+static constexpr std::size_t kBenchCount = 10'000'000;
+#else
+static constexpr std::size_t kBenchCount = 100'000'000;
+#endif
+
+struct Rabbit {
+  Rabbit(int y) { x = y * y; }
+  ~Rabbit() { x = x - x / 2; }
+  volatile int x{0};
+};
+
+void test_shared_ptr_CreationBench() {
+  tests::BenchmarkFunc(
+      [](auto i) {
+        auto rabbit_ptr = std::make_shared<Rabbit>(i);
+        rabbit_ptr->x += static_cast<int>(i) % 100;
+        rabbit_ptr.reset();
+      },
+      kBenchCount, "create and destroy");
+
+  std::vector<std::shared_ptr<Rabbit>> rabbits1;
+  rabbits1.reserve(1000);
+  tests::BenchmarkFunc(
+      [&](auto i) {
+        for (volatile auto j = 0; j < rabbits1.capacity(); j++) {
+          rabbits1.push_back(std::make_shared<Rabbit>(i + j));
+          rabbits1.back()->x += static_cast<int>(i) % 100;
+        }
+        rabbits1.clear();
+      },
+      kBenchCount / rabbits1.capacity(), "create a bunch size ",
+      rabbits1.capacity(), " and destroy all after");
+}
+
+std::vector<std::shared_ptr<Rabbit>> rabbits2;
+void test_shared_ptr_CopyingBench() {
+  tests::BenchmarkFunc(
+      [&](auto i) {
+        rabbits2.push_back(std::make_shared<Rabbit>(i % 1000));
+
+        if (((i + 1) % 10'000) == 0) {
+          rabbits2.clear();
+          rabbits2.shrink_to_fit();
+        }
+      },
+      kBenchCount, "moving inside the vector while it grows max ", 10'000,
+      " elements");
+
+  std::vector<std::shared_ptr<Rabbit>> rabbits3;
+  rabbits3.reserve(1000);
+  for (volatile std::size_t j = 0; j < rabbits3.capacity(); j++) {
+    rabbits3.push_back(std::make_shared<Rabbit>(j));
+  }
+  tests::BenchmarkFunc(
+      [&](auto i) {
+        auto copy_rabbits = rabbits3;
+        for (auto& r : copy_rabbits) {
+          r->x += i % 100;
+        }
+      },
+      kBenchCount / 100, "copying the vector size: ", rabbits3.capacity());
+}
+
+}  // namespace ae::test_shared_ptr_bench
+
+int test_shared_ptr_bench() {
+  UNITY_BEGIN();
+  RUN_TEST(ae::test_shared_ptr_bench::test_shared_ptr_CreationBench);
+  RUN_TEST(ae::test_shared_ptr_bench::test_shared_ptr_CopyingBench);
+  return UNITY_END();
+}


### PR DESCRIPTION
closes #34

Make a RcPtr - a simple replacement for std::shared_ptr to reduce binary size. It's simpler and smaller, but doesn't support polymorphism.