### PR TITLE
77 forbid use pre in non reflectable

### DIFF
--- a/aether/actions/action.h
+++ b/aether/actions/action.h
@@ -132,30 +132,30 @@ class Action : public IAction {
   }
 
   // Call result to mark action as done and call all result callbacks
-  void Result(T const& object) {
+  void Result(T& object) {
     result_cbs_.Emit(object);
     Finish();
   }
 
   // Call result repeat to call all result callbacks without marking action as
   // finished
-  void ResultRepeat(T const& object) { result_cbs_.Emit(object); }
+  void ResultRepeat(T& object) { result_cbs_.Emit(object); }
 
   //  Call error to mark action as failed and call all error callbacks
-  void Error(T const& object) {
+  void Error(T& object) {
     error_cbs_.Emit(object);
     Finish();
   }
 
   // Call stop to mark action as rejected and call all stop callbacks
-  void Stop(T const& object) {
+  void Stop(T& object) {
     stop_cbs_.Emit(object);
     Finish();
   }
 
-  Event<void(T const&)> result_cbs_;
-  Event<void(T const&)> error_cbs_;
-  Event<void(T const&)> stop_cbs_;
+  Event<void(T&)> result_cbs_;
+  Event<void(T&)> error_cbs_;
+  Event<void(T&)> stop_cbs_;
   Event<void()> finished_event_;
 
   ActionTrigger* action_trigger_{};

--- a/aether/adapters/adapter.cpp
+++ b/aether/adapters/adapter.cpp
@@ -45,7 +45,7 @@ void Adapter::CleanDeadTransports() {
 #endif
 }
 
-Ptr<ITransport> Adapter::FindInCache(
+std::unique_ptr<ITransport> Adapter::FindInCache(
     IpAddressPortProtocol /* address_port_protocol */) {
 #if 0
   auto cache_it = transports_cache_.find(address_port_protocol);
@@ -62,9 +62,9 @@ Ptr<ITransport> Adapter::FindInCache(
 }
 
 void Adapter::AddToCache(IpAddressPortProtocol /* address_port_protocol */,
-                         Ptr<ITransport> /* transport */) {
+                         ITransport& /* transport */) {
 #if 0
-  transports_cache_.emplace(address_port_protocol, transport);
+  transports_cache_.emplace(address_port_protocol, std::move(transport));
 #endif
 }
 

--- a/aether/adapters/adapter.h
+++ b/aether/adapters/adapter.h
@@ -34,7 +34,7 @@ class CreateTransportAction : public Action<CreateTransportAction> {
   using Action::Action;
   using Action::operator=;
 
-  virtual Ptr<ITransport> transport() const = 0;
+  virtual std::unique_ptr<ITransport> transport() = 0;
 };
 
 // TODO: make it pure virtual
@@ -61,14 +61,17 @@ class Adapter : public Obj {
 
  protected:
   void CleanDeadTransports();
-  Ptr<ITransport> FindInCache(IpAddressPortProtocol address_port_protocol);
+  // FIXME: unique_ptr in cache ?
+  std::unique_ptr<ITransport> FindInCache(
+      IpAddressPortProtocol address_port_protocol);
   void AddToCache(IpAddressPortProtocol address_port_protocol,
-                  Ptr<ITransport> transport);
+                  ITransport& transport);
 
   Proxy::ptr proxy_prefab_;
   std::vector<Proxy::ptr> proxies_;
 
-  std::map<IpAddressPortProtocol, PtrView<ITransport>> transports_cache_;
+  std::map<IpAddressPortProtocol, std::unique_ptr<ITransport>>
+      transports_cache_;
 };
 
 }  // namespace ae

--- a/aether/adapters/esp32_wifi.cpp
+++ b/aether/adapters/esp32_wifi.cpp
@@ -93,7 +93,8 @@ TimePoint Esp32WifiAdapter::CreateTransportAction::Update(
   return current_time;
 }
 
-Ptr<ITransport> Esp32WifiAdapter::CreateTransportAction::transport() {
+std::unique_ptr<ITransport>
+Esp32WifiAdapter::CreateTransportAction::transport() {
   return std::move(transport_);
 }
 
@@ -104,8 +105,8 @@ void Esp32WifiAdapter::CreateTransportAction::CreateTransport() {
 #  if defined(LWIP_TCP_TRANSPORT_ENABLED)
     assert(address_port_protocol_.protocol == Protocol::kTcp);
     transport_ =
-        MakePtr<LwipTcpTransport>(*aether_.Lock()->action_processor,
-                                  poller_.Lock(), address_port_protocol_);
+        make_unique<LwipTcpTransport>(*aether_.Lock()->action_processor,
+                                      poller_.Lock(), address_port_protocol_);
 #  else
     return {};
 #  endif
@@ -113,7 +114,7 @@ void Esp32WifiAdapter::CreateTransportAction::CreateTransport() {
     AE_TELED_DEBUG("Got transport from cache");
   }
 
-  adapter_->AddToCache(address_port_protocol_, transport_);
+  adapter_->AddToCache(address_port_protocol_, *transport_);
 }
 
 #  if defined AE_DISTILLATION

--- a/aether/adapters/esp32_wifi.h
+++ b/aether/adapters/esp32_wifi.h
@@ -46,29 +46,29 @@ class Esp32WifiAdapter : public ParentWifiAdapter {
 
   Esp32WifiAdapter() = default;
 
-  class CreateTransportAction : public ae::CreateTransportAction {
+  class CreateTransportAction : public CreateTransportAction {
    public:
     // immediately create the transport
     CreateTransportAction(ActionContext action_context,
-                          Esp32WifiAdapter* adapter, Obj::ptr aether,
-                          IPoller::ptr poller,
+                          Esp32WifiAdapter* adapter, Obj::ptr const& aether,
+                          IPoller::ptr const& poller,
                           IpAddressPortProtocol address_port_protocol_);
     // create the transport when wifi is connected
     CreateTransportAction(ActionContext action_context,
                           EventSubscriber<void(bool)> wifi_connected_event,
-                          Esp32WifiAdapter* adapter, Obj::ptr aether,
-                          IPoller::ptr poller,
+                          Esp32WifiAdapter* adapter, Obj::ptr const& aether,
+                          IPoller::ptr const& poller,
                           IpAddressPortProtocol address_port_protocol_);
 
     TimePoint Update(TimePoint current_time) override;
-    Ptr<ITransport> transport() const;
+    Ptr<ITransport> transport();
 
    private:
     void CreateTransport();
 
     Esp32WifiAdapter* adapter_;
-    Obj::ptr aether_;
-    IPoller::ptr poller_;
+    PtrView<Aether> aether_;
+    PtrView<IPoller> poller_;
     IpAddressPortProtocol address_port_protocol_;
 
     bool once_;

--- a/aether/adapters/esp32_wifi.h
+++ b/aether/adapters/esp32_wifi.h
@@ -46,7 +46,7 @@ class Esp32WifiAdapter : public ParentWifiAdapter {
 
   Esp32WifiAdapter() = default;
 
-  class CreateTransportAction : public CreateTransportAction {
+  class CreateTransportAction : public ae::CreateTransportAction {
    public:
     // immediately create the transport
     CreateTransportAction(ActionContext action_context,
@@ -61,7 +61,7 @@ class Esp32WifiAdapter : public ParentWifiAdapter {
                           IpAddressPortProtocol address_port_protocol_);
 
     TimePoint Update(TimePoint current_time) override;
-    Ptr<ITransport> transport();
+    std::unique_ptr<ITransport> transport() override;
 
    private:
     void CreateTransport();
@@ -74,7 +74,7 @@ class Esp32WifiAdapter : public ParentWifiAdapter {
     bool once_;
     bool failed_;
     Subscription wifi_connected_subscription_;
-    Ptr<ITransport> transport_;
+    std::unique_ptr<ITransport> transport_;
   };
 
   static constexpr int kMaxRetry = 10;

--- a/aether/adapters/ethernet.h
+++ b/aether/adapters/ethernet.h
@@ -17,6 +17,9 @@
 #ifndef AETHER_ADAPTERS_ETHERNET_H_
 #define AETHER_ADAPTERS_ETHERNET_H_
 
+#include <optional>
+
+#include "aether/memory.h"
 #include "aether/ptr/ptr.h"
 #include "aether/poller/poller.h"
 #include "aether/adapters/adapter.h"
@@ -32,15 +35,15 @@ class EthernetAdapter : public Adapter {
 
   class EthernetCreateTransportAction : public CreateTransportAction {
    public:
-    explicit EthernetCreateTransportAction(ActionContext action_context,
-                                           Ptr<ITransport> transport);
+    explicit EthernetCreateTransportAction(
+        ActionContext action_context, std::unique_ptr<ITransport> transport);
 
     TimePoint Update(TimePoint current_time) override;
 
-    Ptr<ITransport> transport() const override;
+    std::unique_ptr<ITransport> transport() override;
 
    private:
-    Ptr<ITransport> transport_;
+    std::unique_ptr<ITransport> transport_;
     bool once_;
   };
 
@@ -66,7 +69,8 @@ class EthernetAdapter : public Adapter {
  private:
   Obj::ptr aether_;
   IPoller::ptr poller_;
-  Ptr<ActionList<EthernetCreateTransportAction>> create_transport_actions_;
+  std::optional<ActionList<EthernetCreateTransportAction>>
+      create_transport_actions_;
 };
 }  // namespace ae
 

--- a/aether/ae_actions/get_client_cloud.h
+++ b/aether/ae_actions/get_client_cloud.h
@@ -19,6 +19,7 @@
 
 #include <vector>
 
+#include "aether/memory.h"
 #include "aether/actions/action.h"
 #include "aether/events/multi_subscription.h"
 
@@ -38,9 +39,9 @@ class GetClientCloudAction : public Action<GetClientCloudAction> {
   };
 
  public:
-  explicit GetClientCloudAction(
-      ActionContext action_context,
-      Ptr<ClientToServerStream> client_to_server_stream, Uid client_uid);
+  explicit GetClientCloudAction(ActionContext action_context,
+                                ClientToServerStream& client_to_server_stream,
+                                Uid client_uid);
 
   TimePoint Update(TimePoint current_time) override;
 
@@ -55,13 +56,14 @@ class GetClientCloudAction : public Action<GetClientCloudAction> {
   void OnCloudResponse(UidAndCloud const& uid_and_cloud);
   void OnServerResponse(ServerDescriptor const& server_descriptor);
 
-  Ptr<ClientToServerStream> client_to_server_stream_;
+  ClientToServerStream* client_to_server_stream_;
   Uid client_uid_;
   ProtocolContext protocol_context_;
 
-  Ptr<ByteStream> pre_client_to_server_stream_;
-  Ptr<Stream<Uid, UidAndCloud, DataBuffer, DataBuffer>> cloud_request_stream_;
-  Ptr<Stream<ServerId, ServerDescriptor, DataBuffer, DataBuffer>>
+  std::unique_ptr<ByteStream> pre_client_to_server_stream_;
+  std::unique_ptr<Stream<Uid, UidAndCloud, DataBuffer, DataBuffer>>
+      cloud_request_stream_;
+  std::unique_ptr<Stream<ServerId, ServerDescriptor, DataBuffer, DataBuffer>>
       server_resolver_stream_;
 
   StateMachine<State> state_;

--- a/aether/ae_actions/get_client_cloud_connection.h
+++ b/aether/ae_actions/get_client_cloud_connection.h
@@ -21,6 +21,7 @@
 #include <optional>
 
 #include "aether/uid.h"
+#include "aether/memory.h"
 #include "aether/async_for_loop.h"
 #include "aether/ptr/ptr_view.h"
 #include "aether/actions/action.h"
@@ -52,7 +53,7 @@ class GetClientCloudConnection : public Action<GetClientCloudConnection> {
       ActionContext action_context,
       Ptr<ClientConnectionManager> const& client_connection_manager,
       ObjPtr<Client> const& client, Uid client_uid,
-      Ptr<ServerConnectionSelector> client_server_connection_selector);
+      RcPtr<ServerConnectionSelector> client_server_connection_selector);
 
   ~GetClientCloudConnection() override;
 
@@ -60,7 +61,7 @@ class GetClientCloudConnection : public Action<GetClientCloudConnection> {
 
   void Stop();
 
-  Ptr<ClientConnection> client_cloud_connection() const;
+  std::unique_ptr<ClientConnection> client_cloud_connection();
 
  private:
   void TryCache(TimePoint current_time);
@@ -68,25 +69,26 @@ class GetClientCloudConnection : public Action<GetClientCloudConnection> {
   void GetCloud(TimePoint current_time);
   void CreateConnection(TimePoint current_time);
 
-  Ptr<ClientConnection> CreateConnection(
-      Ptr<ServerConnectionSelector> client_to_server_stream_selector);
+  std::unique_ptr<ClientConnection> CreateConnection(
+      RcPtr<ServerConnectionSelector> client_to_server_stream_selector);
 
   ActionContext action_context_;
   PtrView<Client> client_;
   Uid client_uid_;
   PtrView<ClientConnectionManager> client_connection_manager_;
-  Ptr<ServerConnectionSelector> server_connection_selector_;
-  Ptr<AsyncForLoop<Ptr<ClientServerConnection>>> connection_selection_loop_;
+  RcPtr<ServerConnectionSelector> server_connection_selector_;
+  std::optional<AsyncForLoop<RcPtr<ClientServerConnection>>>
+      connection_selection_loop_;
 
   StateMachine<State> state_;
 
-  Ptr<ClientServerConnection> server_connection_;
+  RcPtr<ClientServerConnection> server_connection_;
   Subscription connection_subscription_;
 
   std::optional<GetClientCloudAction> get_client_cloud_action_;
   MultiSubscription get_client_cloud_subscriptions_;
 
-  Ptr<ClientConnection> client_cloud_connection_;
+  std::unique_ptr<ClientConnection> client_cloud_connection_;
   Subscription state_changed_subscription_;
 };
 }  // namespace ae

--- a/aether/ae_actions/get_client_cloud_connection.h
+++ b/aether/ae_actions/get_client_cloud_connection.h
@@ -34,6 +34,7 @@
 
 namespace ae {
 class Client;
+class Cloud;
 class ClientConnectionManager;
 
 class GetClientCloudConnection : public Action<GetClientCloudConnection> {
@@ -52,8 +53,8 @@ class GetClientCloudConnection : public Action<GetClientCloudConnection> {
   GetClientCloudConnection(
       ActionContext action_context,
       Ptr<ClientConnectionManager> const& client_connection_manager,
-      ObjPtr<Client> const& client, Uid client_uid,
-      RcPtr<ServerConnectionSelector> client_server_connection_selector);
+      ObjPtr<Client> const& client, Uid client_uid, ObjPtr<Cloud> const& cloud,
+      std::unique_ptr<IServerConnectionFactory>&& server_connection_factory);
 
   ~GetClientCloudConnection() override;
 
@@ -61,7 +62,7 @@ class GetClientCloudConnection : public Action<GetClientCloudConnection> {
 
   void Stop();
 
-  std::unique_ptr<ClientConnection> client_cloud_connection();
+  Ptr<ClientConnection> client_cloud_connection();
 
  private:
   void TryCache(TimePoint current_time);
@@ -69,14 +70,11 @@ class GetClientCloudConnection : public Action<GetClientCloudConnection> {
   void GetCloud(TimePoint current_time);
   void CreateConnection(TimePoint current_time);
 
-  std::unique_ptr<ClientConnection> CreateConnection(
-      RcPtr<ServerConnectionSelector> client_to_server_stream_selector);
-
   ActionContext action_context_;
   PtrView<Client> client_;
   Uid client_uid_;
   PtrView<ClientConnectionManager> client_connection_manager_;
-  RcPtr<ServerConnectionSelector> server_connection_selector_;
+  ServerConnectionSelector server_connection_selector_;
   std::optional<AsyncForLoop<RcPtr<ClientServerConnection>>>
       connection_selection_loop_;
 
@@ -88,7 +86,7 @@ class GetClientCloudConnection : public Action<GetClientCloudConnection> {
   std::optional<GetClientCloudAction> get_client_cloud_action_;
   MultiSubscription get_client_cloud_subscriptions_;
 
-  std::unique_ptr<ClientConnection> client_cloud_connection_;
+  Ptr<ClientConnection> client_cloud_connection_;
   Subscription state_changed_subscription_;
 };
 }  // namespace ae

--- a/aether/ae_actions/ping.cpp
+++ b/aether/ae_actions/ping.cpp
@@ -24,13 +24,13 @@
 #include "aether/tele/tele.h"
 
 namespace ae {
-Ping::Ping(ActionContext action_context, Server::ptr server,
-           Channel::ptr channel, Ptr<ByteStream> server_stream,
+Ping::Ping(ActionContext action_context, Server::ptr const& server,
+           Channel::ptr const& channel, ByteStream& server_stream,
            Duration ping_interval)
     : Action{action_context},
-      server_{std::move(server)},
-      channel_{std::move(channel)},
-      server_stream_{std::move(server_stream)},
+      server_{server},
+      channel_{channel},
+      server_stream_{&server_stream},
       ping_interval_{ping_interval},
       read_client_safe_api_gate_{protocol_context_, client_safe_api_},
       state_{State::kSendPing},

--- a/aether/ae_actions/ping.h
+++ b/aether/ae_actions/ping.h
@@ -41,8 +41,9 @@ class Ping : public Action<Ping> {
   };
 
  public:
-  Ping(ActionContext action_context, Server::ptr server, Channel::ptr channel,
-       Ptr<ByteStream> server_stream, Duration ping_interval);
+  Ping(ActionContext action_context, Server::ptr const& server,
+       Channel::ptr const& channel, ByteStream& server_stream,
+       Duration ping_interval);
   ~Ping() override;
 
   AE_CLASS_NO_COPY_MOVE(Ping);
@@ -53,9 +54,9 @@ class Ping : public Action<Ping> {
   void SendPing(TimePoint current_time);
   void PingResponse();
 
-  Server::ptr server_;
-  Channel::ptr channel_;
-  Ptr<ByteStream> server_stream_;
+  PtrView<Server> server_;
+  PtrView<Channel> channel_;
+  ByteStream* server_stream_;
   Duration ping_interval_;
 
   ProtocolContext protocol_context_;

--- a/aether/ae_actions/registration/registration.h
+++ b/aether/ae_actions/registration/registration.h
@@ -25,6 +25,9 @@
 
 #  include "aether/uid.h"
 #  include "aether/common.h"
+#  include "aether/memory.h"
+#  include "aether/ptr/ptr.h"
+#  include "aether/ptr/ptr_view.h"
 #  include "aether/state_machine.h"
 #  include "aether/actions/action.h"
 #  include "aether/actions/action_view.h"
@@ -89,21 +92,22 @@ class Registration : public Action<Registration> {
   void OnResolveCloudResponse(
       MessageEventData<ClientApiRegSafe::ResolveServersResponse> const& msg);
 
-  Ptr<ByteStream> CreateRegServerStream(
-      StreamId stream_id, Ptr<IAsyncKeyProvider> async_key_provider,
-      Ptr<ISyncKeyProvider> sync_key_provider);
-  Ptr<ByteStream> CreateGlobalRegServerStream(
+  std::unique_ptr<ByteStream> CreateRegServerStream(
+      StreamId stream_id, std::unique_ptr<IAsyncKeyProvider> async_key_provider,
+      std::unique_ptr<ISyncKeyProvider> sync_key_provider);
+  std::unique_ptr<ByteStream> CreateGlobalRegServerStream(
       StreamId stream_id, ServerRegistrationApi::Registration message,
-      Ptr<IAsyncKeyProvider> global_async_key_provider,
-      Ptr<ISyncKeyProvider> global_sync_key_provider);
+      std::unique_ptr<IAsyncKeyProvider> global_async_key_provider,
+      std::unique_ptr<ISyncKeyProvider> global_sync_key_provider);
 
   PtrView<Aether> aether_;
   Ptr<Client> client_;
   Uid parent_uid_;
 
-  Ptr<ServerList> server_list_;
-  Ptr<AsyncForLoop<Ptr<ServerChannelStream>>> connection_selection_;
-  Ptr<ServerChannelStream> server_channel_stream_;
+  std::unique_ptr<ServerList> server_list_;
+  std::optional<AsyncForLoop<std::unique_ptr<ServerChannelStream>>>
+      connection_selection_;
+  std::unique_ptr<ServerChannelStream> server_channel_stream_;
   ProtocolContext protocol_context_;
   ClientApiRegSafe root_api_;
 
@@ -121,11 +125,11 @@ class Registration : public Action<Registration> {
   Key aether_global_key_;
   std::vector<ServerId> cloud_;
 
-  Ptr<class RegistrationAsyncKeyProvider> server_async_key_provider_;
-  Ptr<class RegistrationSyncKeyProvider> server_sync_key_provider_;
+  class RegistrationAsyncKeyProvider* server_async_key_provider_;
+  class RegistrationSyncKeyProvider* server_sync_key_provider_;
 
-  Ptr<ByteStream> reg_server_stream_;
-  Ptr<ByteStream> global_reg_server_stream_;
+  std::unique_ptr<ByteStream> reg_server_stream_;
+  std::unique_ptr<ByteStream> global_reg_server_stream_;
 
   ActionView<StreamWriteAction> packet_write_action_;
   Subscription connection_subscription_;

--- a/aether/aether_app.cpp
+++ b/aether/aether_app.cpp
@@ -107,6 +107,7 @@ AetherApp::~AetherApp() {
     domain_->SaveRoot(aether_);
   }
   AE_TELED_DEBUG("Reset Aether");
+  ae::TeleInit::Init();
   aether_.Reset();
 }
 

--- a/aether/async_for_loop.h
+++ b/aether/async_for_loop.h
@@ -83,9 +83,9 @@ class AsyncForLoop {
       auto res = body_();
       Increment();
       if constexpr (IsOptional<BodyReturnType>::value) {
-        return std::optional{res};
+        return std::optional{std::move(res)};
       } else {
-        return res;
+        return std::move(res);
       }
     }
     return {};

--- a/aether/client.cpp
+++ b/aether/client.cpp
@@ -61,11 +61,11 @@ void Client::SetConfig(Uid uid, Uid ephemeral_uid, Key master_key,
       ObjPtr<Aether>{aether_}, MakePtrFromThis(this));
 }
 
-Ptr<ClientConnection> Client::client_connection() {
+ClientConnection& Client::client_connection() {
   if (!client_connection_) {
     client_connection_ = client_connection_manager_->GetClientConnection();
   }
-  return client_connection_;
+  return *client_connection_;
 }
 
 }  // namespace ae

--- a/aether/client.cpp
+++ b/aether/client.cpp
@@ -61,11 +61,11 @@ void Client::SetConfig(Uid uid, Uid ephemeral_uid, Key master_key,
       ObjPtr<Aether>{aether_}, MakePtrFromThis(this));
 }
 
-ClientConnection& Client::client_connection() {
+Ptr<ClientConnection> const& Client::client_connection() {
   if (!client_connection_) {
     client_connection_ = client_connection_manager_->GetClientConnection();
   }
-  return *client_connection_;
+  return client_connection_;
 }
 
 }  // namespace ae

--- a/aether/client.h
+++ b/aether/client.h
@@ -50,7 +50,7 @@ class Client : public Obj {
   Cloud::ptr const& cloud() const;
   ClientConnectionManager::ptr const& client_connection_manager() const;
 
-  Ptr<ClientConnection> client_connection();
+  ClientConnection& client_connection();
 
   void SetConfig(Uid uid, Uid ephemeral_uid, Key master_key, Cloud::ptr c);
 
@@ -64,6 +64,7 @@ class Client : public Obj {
     dnv(aether_, uid_, ephemeral_uid_, master_key_, cloud_, server_keys_,
         client_connection_manager_);
   }
+
   template <typename Dnv>
   void Save(CurrentVersion, Dnv& dnv) const {
     dnv(base_);
@@ -86,7 +87,7 @@ class Client : public Obj {
   std::map<ServerId, ServerKeys> server_keys_;
 
   ClientConnectionManager::ptr client_connection_manager_;
-  Ptr<ClientConnection> client_connection_;
+  std::unique_ptr<ClientConnection> client_connection_;
 };
 }  // namespace ae
 

--- a/aether/client.h
+++ b/aether/client.h
@@ -50,7 +50,7 @@ class Client : public Obj {
   Cloud::ptr const& cloud() const;
   ClientConnectionManager::ptr const& client_connection_manager() const;
 
-  ClientConnection& client_connection();
+  Ptr<ClientConnection> const& client_connection();
 
   void SetConfig(Uid uid, Uid ephemeral_uid, Key master_key, Cloud::ptr c);
 
@@ -87,7 +87,7 @@ class Client : public Obj {
   std::map<ServerId, ServerKeys> server_keys_;
 
   ClientConnectionManager::ptr client_connection_manager_;
-  std::unique_ptr<ClientConnection> client_connection_;
+  Ptr<ClientConnection> client_connection_;
 };
 }  // namespace ae
 

--- a/aether/client_connections/client_cloud_connection.cpp
+++ b/aether/client_connections/client_cloud_connection.cpp
@@ -23,7 +23,7 @@
 namespace ae {
 ClientCloudConnection::ClientCloudConnection(
     ActionContext action_context,
-    Ptr<ServerConnectionSelector> client_server_connection_selector)
+    RcPtr<ServerConnectionSelector> client_server_connection_selector)
     : action_context_{action_context},
       server_connection_selector_{
           std::move(client_server_connection_selector)} {
@@ -31,36 +31,37 @@ ClientCloudConnection::ClientCloudConnection(
 }
 
 void ClientCloudConnection::Connect() {
-  connection_selector_loop_ = MakePtr<AsyncForLoop>(
-      AsyncForLoop<Ptr<ClientServerConnection>>::Construct(
+  connection_selector_loop_ =
+      AsyncForLoop<RcPtr<ClientServerConnection>>::Construct(
           *server_connection_selector_,
-          [this]() { return server_connection_selector_->GetConnection(); }));
+          [this]() { return server_connection_selector_->GetConnection(); });
 
   SelectConnection();
 }
 
-Ptr<ByteStream> ClientCloudConnection::CreateStream(Uid destination_uid,
-                                                    StreamId stream_id) {
+std::unique_ptr<ByteStream> ClientCloudConnection::CreateStream(
+    Uid destination_uid, StreamId stream_id) {
   AE_TELED_DEBUG("CreateStream destination uid {}, stream id {}",
                  destination_uid, static_cast<int>(stream_id));
   assert(server_connection_);
 
   auto gate_it = gates_.find(destination_uid);
   if (gate_it != gates_.end()) {
-    return MakePtr<OneGateStream>(gate_it->second->RegisterStream(stream_id));
+    return make_unique<OneGateStream>(
+        gate_it->second->RegisterStream(stream_id));
   }
 
   auto& stream = server_connection_->GetStream(destination_uid);
-  gate_it =
-      gates_.emplace_hint(gate_it, destination_uid, MakePtr<SplitterGate>());
+  gate_it = gates_.emplace_hint(gate_it, destination_uid,
+                                make_unique<SplitterGate>());
   Tie(*gate_it->second, stream);
   new_split_stream_subscription_.Push(
       gate_it->second->new_stream_event().Subscribe(
           [this, destination_uid](auto id, auto& stream) {
             new_stream_event_.Emit(destination_uid, id,
-                                   MakePtr<OneGateStream>(stream));
+                                   make_unique<OneGateStream>(stream));
           }));
-  return MakePtr<OneGateStream>(gate_it->second->RegisterStream(stream_id));
+  return make_unique<OneGateStream>(gate_it->second->RegisterStream(stream_id));
 }
 
 ClientCloudConnection::NewStreamEvent::Subscriber
@@ -92,11 +93,11 @@ void ClientCloudConnection::SelectConnection() {
 
   connection_status_subscription_ =
       server_connection_->server_stream()
-          ->in()
+          .in()
           .gate_update_event()
           .Subscribe([this]() {
             if (server_connection_->server_stream()
-                    ->in()
+                    .in()
                     .stream_info()
                     .is_linked) {
               AE_TELED_INFO("Client cloud connection is connected");
@@ -113,7 +114,7 @@ void ClientCloudConnection::SelectConnection() {
 
   new_stream_event_subscription_ =
       server_connection_->new_stream_event().Subscribe(
-          [this](auto uid, auto stream) { NewStream(uid, std::move(stream)); });
+          [this](auto uid, auto& stream) { NewStream(uid, stream); });
 }
 
 void ClientCloudConnection::OnConnectionError() {
@@ -128,23 +129,23 @@ void ClientCloudConnection::OnConnectionError() {
   reconnect_notify_.Notify();
 }
 
-void ClientCloudConnection::NewStream(Uid uid, Ptr<ByteStream> stream) {
+void ClientCloudConnection::NewStream(Uid uid, ByteStream& stream) {
   AE_TELED_DEBUG("New stream for uid {}", uid);
 
   auto gate_it = gates_.find(uid);
   if (gate_it != std::end(gates_)) {
     // retie existing stream
-    Tie(*gate_it->second, *stream);
+    Tie(*gate_it->second, stream);
     return;
   }
 
   // new stream created
-  gate_it = gates_.emplace_hint(gate_it, uid, MakePtr<SplitterGate>());
-  Tie(*gate_it->second, *stream);
+  gate_it = gates_.emplace_hint(gate_it, uid, make_unique<SplitterGate>());
+  Tie(*gate_it->second, stream);
   new_split_stream_subscription_.Push(
       gate_it->second->new_stream_event().Subscribe(
           [this, uid](auto id, auto& stream) {
-            new_stream_event_.Emit(uid, id, MakePtr<OneGateStream>(stream));
+            new_stream_event_.Emit(uid, id, make_unique<OneGateStream>(stream));
           }));
 }
 

--- a/aether/client_connections/client_cloud_connection.h
+++ b/aether/client_connections/client_cloud_connection.h
@@ -18,8 +18,10 @@
 #define AETHER_CLIENT_CONNECTIONS_CLIENT_CLOUD_CONNECTION_H_
 
 #include <map>
+#include <optional>
 
 #include "aether/uid.h"
+#include "aether/memory.h"
 #include "aether/async_for_loop.h"
 #include "aether/actions/action.h"
 #include "aether/events/event_subscription.h"
@@ -41,11 +43,11 @@ class ClientCloudConnection final : public ClientConnection {
  public:
   explicit ClientCloudConnection(
       ActionContext action_context,
-      Ptr<ServerConnectionSelector> client_server_connection_selector);
+      RcPtr<ServerConnectionSelector> client_server_connection_selector);
 
   void Connect() override;
-  Ptr<ByteStream> CreateStream(Uid destination_uid,
-                               StreamId stream_id) override;
+  std::unique_ptr<ByteStream> CreateStream(Uid destination_uid,
+                                           StreamId stream_id) override;
   NewStreamEvent::Subscriber new_stream_event() override;
   void CloseStream(Uid uid, StreamId stream_id) override;
 
@@ -53,14 +55,15 @@ class ClientCloudConnection final : public ClientConnection {
   void SelectConnection();
 
   void OnConnectionError();
-  void NewStream(Uid uid, Ptr<ByteStream> stream);
+  void NewStream(Uid uid, ByteStream& stream);
 
   ActionContext action_context_;
-  Ptr<ServerConnectionSelector> server_connection_selector_;
-  Ptr<AsyncForLoop<Ptr<ClientServerConnection>>> connection_selector_loop_;
+  RcPtr<ServerConnectionSelector> server_connection_selector_;
+  std::optional<AsyncForLoop<RcPtr<ClientServerConnection>>>
+      connection_selector_loop_;
 
   // currently selected connection
-  Ptr<ClientServerConnection> server_connection_;
+  RcPtr<ClientServerConnection> server_connection_;
 
   NewStreamEvent new_stream_event_;
   Subscription new_stream_event_subscription_;
@@ -69,7 +72,7 @@ class ClientCloudConnection final : public ClientConnection {
   Subscription connection_status_subscription_;
 
   // known streams to clients
-  std::map<Uid, Ptr<SplitterGate>> gates_;
+  std::map<Uid, std::unique_ptr<SplitterGate>> gates_;
 
   ReconnectNotify reconnect_notify_;
   Subscription reconnect_notify_subscription_;

--- a/aether/client_connections/client_connection.h
+++ b/aether/client_connections/client_connection.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "aether/uid.h"
+#include "aether/reflect/reflect.h"
 #include "aether/stream_api/istream.h"
 #include "aether/stream_api/stream_api.h"
 
@@ -54,6 +55,8 @@ class ClientConnection {
    * \brief Close a stream by uid and id.
    */
   virtual void CloseStream(Uid uid, StreamId stream_id) = 0;
+
+  AE_CLASS_REFLECT()
 };
 }  // namespace ae
 

--- a/aether/client_connections/client_connection.h
+++ b/aether/client_connections/client_connection.h
@@ -17,8 +17,9 @@
 #ifndef AETHER_CLIENT_CONNECTIONS_CLIENT_CONNECTION_H_
 #define AETHER_CLIENT_CONNECTIONS_CLIENT_CONNECTION_H_
 
+#include <memory>
+
 #include "aether/uid.h"
-#include "aether/ptr/ptr.h"
 #include "aether/stream_api/istream.h"
 #include "aether/stream_api/stream_api.h"
 
@@ -28,8 +29,8 @@ namespace ae {
  */
 class ClientConnection {
  public:
-  using NewStreamEvent =
-      Event<void(Uid uid, StreamId stream_id, Ptr<ByteStream> stream)>;
+  using NewStreamEvent = Event<void(Uid uid, StreamId stream_id,
+                                    std::unique_ptr<ByteStream> stream)>;
 
   virtual ~ClientConnection() = default;
 
@@ -41,8 +42,8 @@ class ClientConnection {
   /**
    * \brief Create a stream to another client to send messages.
    */
-  virtual Ptr<ByteStream> CreateStream(Uid destination_uid,
-                                       StreamId stream_id) = 0;
+  virtual std::unique_ptr<ByteStream> CreateStream(Uid destination_uid,
+                                                   StreamId stream_id) = 0;
 
   /**
    * \brief Event when a new stream is opened by another client.

--- a/aether/client_connections/client_connection_manager.h
+++ b/aether/client_connections/client_connection_manager.h
@@ -37,12 +37,16 @@ namespace ae {
 class Aether;
 class Client;
 
+namespace ccm_internal {
+class CachedServerConnectionFactory;
+}
+
 class ClientConnectionManager : public Obj {
+  friend class ccm_internal::CachedServerConnectionFactory;
+
   AE_OBJECT(ClientConnectionManager, Obj, 0)
 
   ClientConnectionManager() = default;
-
-  friend class CachedServerConnectionFactory;
 
  public:
   explicit ClientConnectionManager(ObjPtr<Aether> aether, ObjPtr<Client> client,
@@ -50,13 +54,13 @@ class ClientConnectionManager : public Obj {
 
   AE_CLASS_NO_COPY_MOVE(ClientConnectionManager)
 
-  std::unique_ptr<ClientConnection> GetClientConnection();
+  Ptr<ClientConnection> GetClientConnection();
   ActionView<GetClientCloudConnection> GetClientConnection(Uid client_uid);
 
-  void RegisterCloud(Uid uid,
-                     std::vector<ServerDescriptor> const& server_descriptors);
+  Ptr<ClientConnection> CreateClientConnection(Cloud::ptr const& cloud);
 
-  RcPtr<ServerConnectionSelector> GetCloudServerConnectionSelector(Uid uid);
+  Cloud::ptr RegisterCloud(
+      Uid uid, std::vector<ServerDescriptor> const& server_descriptors);
 
   AE_OBJECT_REFLECT(aether_, client_, cloud_cache_,
                     client_server_connection_pool_,

--- a/aether/client_connections/client_connection_manager.h
+++ b/aether/client_connections/client_connection_manager.h
@@ -21,6 +21,7 @@
 
 #include "aether/obj/obj.h"
 #include "aether/ptr/ptr.h"
+#include "aether/ptr/rc_ptr.h"
 #include "aether/actions/action_view.h"
 #include "aether/actions/action_list.h"
 
@@ -49,13 +50,13 @@ class ClientConnectionManager : public Obj {
 
   AE_CLASS_NO_COPY_MOVE(ClientConnectionManager)
 
-  Ptr<ClientConnection> GetClientConnection();
+  std::unique_ptr<ClientConnection> GetClientConnection();
   ActionView<GetClientCloudConnection> GetClientConnection(Uid client_uid);
 
   void RegisterCloud(Uid uid,
                      std::vector<ServerDescriptor> const& server_descriptors);
 
-  Ptr<ServerConnectionSelector> GetCloudServerConnectionSelector(Uid uid);
+  RcPtr<ServerConnectionSelector> GetCloudServerConnectionSelector(Uid uid);
 
   AE_OBJECT_REFLECT(aether_, client_, cloud_cache_,
                     client_server_connection_pool_,
@@ -81,7 +82,8 @@ class ClientConnectionManager : public Obj {
   CloudCache cloud_cache_;
   ClientServerConnectionPool client_server_connection_pool_;
 
-  Ptr<ActionList<GetClientCloudConnection>> get_client_cloud_connections_;
+  std::optional<ActionList<GetClientCloudConnection>>
+      get_client_cloud_connections_;
 };
 }  // namespace ae
 

--- a/aether/client_connections/client_server_connection.h
+++ b/aether/client_connections/client_server_connection.h
@@ -21,6 +21,7 @@
 #include "aether/stream_api/istream.h"
 #include "aether/actions/action_context.h"
 
+#include "aether/memory.h"
 #include "aether/server.h"
 #include "aether/channel.h"
 #include "aether/ae_actions/ping.h"
@@ -33,22 +34,23 @@ namespace ae {
  */
 class ClientServerConnection {
  public:
-  using NewStreamEvent = Event<void(Uid uid, Ptr<MessageStream> stream)>;
+  using NewStreamEvent = Event<void(Uid uid, MessageStream& stream)>;
 
   explicit ClientServerConnection(
-      ActionContext action_context, Server::ptr server, Channel::ptr channel,
-      Ptr<ClientToServerStream> client_to_server_stream);
+      ActionContext action_context, Server::ptr const& server,
+      Channel::ptr const& channel,
+      std::unique_ptr<ClientToServerStream> client_to_server_stream);
 
-  Ptr<ClientToServerStream> const& server_stream() const;
+  ClientToServerStream& server_stream();
 
   ByteStream& GetStream(Uid destination);
   NewStreamEvent::Subscriber new_stream_event();
   void CloseStream(Uid uid);
 
  private:
-  Ptr<ClientToServerStream> server_stream_;
-  Ptr<MessageStreamDispatcher> message_stream_dispatcher_;
-  Ptr<Ping> ping_;
+  std::unique_ptr<ClientToServerStream> server_stream_;
+  std::unique_ptr<MessageStreamDispatcher> message_stream_dispatcher_;
+  std::unique_ptr<Ping> ping_;
   NewStreamEvent new_stream_event_;
   Subscription new_stream_event_subscription_;
 };

--- a/aether/client_connections/client_server_connection_pool.cpp
+++ b/aether/client_connections/client_server_connection_pool.cpp
@@ -18,14 +18,14 @@
 
 namespace ae {
 
-Ptr<ClientServerConnection> ClientServerConnectionPool::Find(
+RcPtr<ClientServerConnection> ClientServerConnectionPool::Find(
     ServerId server_id, ObjId channel_obj_id) {
   auto key = Key{server_id, channel_obj_id};
   auto it = connections_.find(key);
   if (it == std::end(connections_)) {
     return {};
   }
-  auto connection = it->second.Lock();
+  auto connection = it->second.lock();
   if (!connection) {
     connections_.erase(it);
     return {};
@@ -35,7 +35,7 @@ Ptr<ClientServerConnection> ClientServerConnectionPool::Find(
 
 void ClientServerConnectionPool::Add(
     ServerId server_id, ObjId channel_obj_id,
-    Ptr<ClientServerConnection> const& connection) {
+    RcPtr<ClientServerConnection> const& connection) {
   auto key = Key{server_id, channel_obj_id};
   connections_[key] = connection;
 }

--- a/aether/client_connections/client_server_connection_pool.h
+++ b/aether/client_connections/client_server_connection_pool.h
@@ -25,6 +25,9 @@
 #include "aether/client_connections/client_server_connection.h"
 
 namespace ae {
+/**
+ * \brief Cache storage for client's connection to servers.
+ */
 class ClientServerConnectionPool {
   struct Key {
     friend bool operator<(Key const& left, Key const& right) {

--- a/aether/client_connections/client_server_connection_pool.h
+++ b/aether/client_connections/client_server_connection_pool.h
@@ -21,7 +21,7 @@
 
 #include "aether/common.h"
 #include "aether/obj/obj_id.h"
-#include "aether/ptr/ptr_view.h"
+#include "aether/ptr/rc_ptr.h"
 #include "aether/client_connections/client_server_connection.h"
 
 namespace ae {
@@ -42,12 +42,12 @@ class ClientServerConnectionPool {
   ClientServerConnectionPool() = default;
   AE_CLASS_NO_COPY_MOVE(ClientServerConnectionPool);
 
-  Ptr<ClientServerConnection> Find(ServerId server_id, ObjId channel_obj_id);
+  RcPtr<ClientServerConnection> Find(ServerId server_id, ObjId channel_obj_id);
   void Add(ServerId server_id, ObjId channel_obj_id,
-           Ptr<ClientServerConnection> const& connection);
+           RcPtr<ClientServerConnection> const& connection);
 
  private:
-  std::map<Key, PtrView<ClientServerConnection>> connections_;
+  std::map<Key, RcPtrView<ClientServerConnection>> connections_;
 };
 }  // namespace ae
 

--- a/aether/client_connections/client_to_server_stream.h
+++ b/aether/client_connections/client_to_server_stream.h
@@ -19,6 +19,8 @@
 
 #include <optional>
 
+#include "aether/memory.h"
+#include "aether/ptr/ptr_view.h"
 #include "aether/events/events.h"
 #include "aether/actions/action_context.h"
 
@@ -38,8 +40,9 @@ class Client;
 
 class ClientToServerStream : public ByteStream {
  public:
-  ClientToServerStream(ActionContext action_context, Ptr<Client> client,
-                       ServerId server_id, Ptr<ByteStream> server_stream);
+  ClientToServerStream(ActionContext action_context, Ptr<Client> const& client,
+                       ServerId server_id,
+                       std::unique_ptr<ByteStream> server_stream);
 
   ~ClientToServerStream() override;
 
@@ -53,7 +56,7 @@ class ClientToServerStream : public ByteStream {
   void OnDisconnected();
 
   ActionContext action_context_;
-  Ptr<Client> client_;
+  PtrView<Client> client_;
   ServerId server_id_;
 
   ProtocolContext protocol_context_;
@@ -64,7 +67,7 @@ class ClientToServerStream : public ByteStream {
   // stream to the server with login api and encryption
   std::optional<
       TiedStream<DebugGate, CryptoGate, StreamApiGate, ProtocolWriteGate,
-                 ProtocolReadGate<ClientSafeApi>, Ptr<ByteStream>>>
+                 ProtocolReadGate<ClientSafeApi>, std::unique_ptr<ByteStream>>>
       client_auth_stream_;
 
   Subscription connection_success_subscription_;

--- a/aether/client_connections/cloud_cache.cpp
+++ b/aether/client_connections/cloud_cache.cpp
@@ -17,16 +17,17 @@
 #include "aether/client_connections/cloud_cache.h"
 
 namespace ae {
-CloudCache::Entry* CloudCache::GetCache(Uid uid) {
+std::optional<std::reference_wrapper<Cloud::ptr>> CloudCache::GetCache(
+    Uid uid) {
   auto it = clouds_.find(uid);
   if (it == std::end(clouds_)) {
-    return nullptr;
+    return {};
   }
-  return &it->second;
+  return std::ref(it->second);
 }
 
 void CloudCache::AddCloud(Uid uid, Cloud::ptr cloud) {
-  clouds_[uid] = Entry{std::move(cloud), {}};
+  clouds_[uid] = std::move(cloud);
 }
 
 }  // namespace ae

--- a/aether/client_connections/cloud_cache.h
+++ b/aether/client_connections/cloud_cache.h
@@ -18,6 +18,8 @@
 #define AETHER_CLIENT_CONNECTIONS_CLOUD_CACHE_H_
 
 #include <map>
+#include <optional>
+#include <functional>
 
 #include "aether/common.h"
 #include "aether/uid.h"
@@ -31,23 +33,16 @@ namespace ae {
  */
 class CloudCache {
  public:
-  struct Entry {
-    AE_CLASS_REFLECT(cloud)
-
-    Cloud::ptr cloud;
-    Ptr<ServerConnectionSelector> client_stream_selector;
-  };
-
   CloudCache() = default;
   AE_CLASS_NO_COPY_MOVE(CloudCache)
 
-  Entry* GetCache(Uid uid);
+  std::optional<std::reference_wrapper<Cloud::ptr>> GetCache(Uid uid);
   void AddCloud(Uid uid, Cloud::ptr cloud);
 
   AE_CLASS_REFLECT(clouds_)
 
  private:
-  std::map<Uid, Entry> clouds_;
+  std::map<Uid, Cloud::ptr> clouds_;
 };
 }  // namespace ae
 

--- a/aether/client_connections/iserver_connection_factory.h
+++ b/aether/client_connections/iserver_connection_factory.h
@@ -17,10 +17,9 @@
 #ifndef AETHER_CLIENT_CONNECTIONS_ISERVER_CONNECTION_FACTORY_H_
 #define AETHER_CLIENT_CONNECTIONS_ISERVER_CONNECTION_FACTORY_H_
 
-#include "aether/ptr/ptr.h"
-
 #include "aether/server.h"
 #include "aether/channel.h"
+#include "aether/ptr/rc_ptr.h"
 #include "aether/client_connections/client_server_connection.h"
 
 namespace ae {
@@ -28,7 +27,7 @@ class IServerConnectionFactory {
  public:
   virtual ~IServerConnectionFactory() = default;
 
-  virtual Ptr<ClientServerConnection> CreateConnection(
+  virtual RcPtr<ClientServerConnection> CreateConnection(
       Server::ptr const& server, Channel::ptr const& channel) = 0;
 };
 }  // namespace ae

--- a/aether/client_connections/server_connection_selector.cpp
+++ b/aether/client_connections/server_connection_selector.cpp
@@ -18,26 +18,25 @@
 
 #include <utility>
 
-#include "aether/server_list/no_filter_server_list_policy.h"
-
 namespace ae {
 ServerConnectionSelector::ServerConnectionSelector(
-    Cloud::ptr const& cloud,
-    std::unique_ptr<IServerConnectionFactory> client_server_connection_factory)
-    : server_list_{make_unique<ServerList>(
-          make_unique<NoFilterServerListPolicy>(), cloud)},
+    ObjPtr<Cloud> const& cloud,
+    std::unique_ptr<ServerListPolicy>&& server_list_policy,
+    std::unique_ptr<IServerConnectionFactory>&&
+        client_server_connection_factory)
+    : server_list_{std::move(server_list_policy), cloud},
       server_connection_factory_{std::move(client_server_connection_factory)} {}
 
-void ServerConnectionSelector::Init() { server_list_->Init(); }
+void ServerConnectionSelector::Init() { server_list_.Init(); }
 
-void ServerConnectionSelector::Next() { server_list_->Next(); }
+void ServerConnectionSelector::Next() { server_list_.Next(); }
 
 RcPtr<ClientServerConnection> ServerConnectionSelector::GetConnection() {
-  auto item = server_list_->Get();
+  auto item = server_list_.Get();
   return server_connection_factory_->CreateConnection(item.server(),
                                                       item.channel());
 }
 
-bool ServerConnectionSelector::End() { return server_list_->End(); }
+bool ServerConnectionSelector::End() { return server_list_.End(); }
 
 }  // namespace ae

--- a/aether/client_connections/server_connection_selector.cpp
+++ b/aether/client_connections/server_connection_selector.cpp
@@ -22,17 +22,17 @@
 
 namespace ae {
 ServerConnectionSelector::ServerConnectionSelector(
-    Ptr<Cloud> cloud,
-    Ptr<IServerConnectionFactory> client_server_connection_factory)
-    : server_list_{MakePtr<ServerList>(MakePtr<NoFilterServerListPolicy>(),
-                                       std::move(cloud))},
+    Cloud::ptr const& cloud,
+    std::unique_ptr<IServerConnectionFactory> client_server_connection_factory)
+    : server_list_{make_unique<ServerList>(
+          make_unique<NoFilterServerListPolicy>(), cloud)},
       server_connection_factory_{std::move(client_server_connection_factory)} {}
 
 void ServerConnectionSelector::Init() { server_list_->Init(); }
 
 void ServerConnectionSelector::Next() { server_list_->Next(); }
 
-Ptr<ClientServerConnection> ServerConnectionSelector::GetConnection() {
+RcPtr<ClientServerConnection> ServerConnectionSelector::GetConnection() {
   auto item = server_list_->Get();
   return server_connection_factory_->CreateConnection(item.server(),
                                                       item.channel());

--- a/aether/client_connections/server_connection_selector.h
+++ b/aether/client_connections/server_connection_selector.h
@@ -17,30 +17,31 @@
 #ifndef AETHER_CLIENT_CONNECTIONS_SERVER_CONNECTION_SELECTOR_H_
 #define AETHER_CLIENT_CONNECTIONS_SERVER_CONNECTION_SELECTOR_H_
 
-#include <type_traits>
-
-#include "aether/cloud.h"
 #include "aether/memory.h"
+#include "aether/ptr/rc_ptr.h"
 #include "aether/server_list/server_list.h"
 #include "aether/client_connections/client_server_connection.h"
 #include "aether/client_connections/iserver_connection_factory.h"
 
 namespace ae {
-// TODO: add an iterator interface maybe ?
+class Cloud;
+
 class ServerConnectionSelector {
  public:
-  ServerConnectionSelector(Cloud::ptr const& cloud,
-                           std::unique_ptr<IServerConnectionFactory>
-                               client_server_connection_factory);
+  ServerConnectionSelector(
+      ObjPtr<Cloud> const& cloud,
+      std::unique_ptr<ServerListPolicy>&& server_list_policy,
+      std::unique_ptr<IServerConnectionFactory>&&
+          client_server_connection_factory);
 
   void Init();
   void Next();
-  // Return stream to current server
+  // Return connection to current server
   RcPtr<ClientServerConnection> GetConnection();
   bool End();
 
  private:
-  std::unique_ptr<ServerList> server_list_;
+  ServerList server_list_;
   std::unique_ptr<IServerConnectionFactory> server_connection_factory_;
 };
 }  // namespace ae

--- a/aether/client_connections/server_connection_selector.h
+++ b/aether/client_connections/server_connection_selector.h
@@ -20,6 +20,7 @@
 #include <type_traits>
 
 #include "aether/cloud.h"
+#include "aether/memory.h"
 #include "aether/server_list/server_list.h"
 #include "aether/client_connections/client_server_connection.h"
 #include "aether/client_connections/iserver_connection_factory.h"
@@ -28,19 +29,19 @@ namespace ae {
 // TODO: add an iterator interface maybe ?
 class ServerConnectionSelector {
  public:
-  ServerConnectionSelector(
-      Ptr<Cloud> cloud,
-      Ptr<IServerConnectionFactory> client_server_connection_factory);
+  ServerConnectionSelector(Cloud::ptr const& cloud,
+                           std::unique_ptr<IServerConnectionFactory>
+                               client_server_connection_factory);
 
   void Init();
   void Next();
   // Return stream to current server
-  Ptr<ClientServerConnection> GetConnection();
+  RcPtr<ClientServerConnection> GetConnection();
   bool End();
 
  private:
-  Ptr<ServerList> server_list_;
-  Ptr<IServerConnectionFactory> server_connection_factory_;
+  std::unique_ptr<ServerList> server_list_;
+  std::unique_ptr<IServerConnectionFactory> server_connection_factory_;
 };
 }  // namespace ae
 

--- a/aether/client_messages/message_stream_dispatcher.cpp
+++ b/aether/client_messages/message_stream_dispatcher.cpp
@@ -54,10 +54,10 @@ void MessageStreamDispatcher::CloseStream(Uid uid) {
   }
 }
 
-Ptr<MessageStream> MessageStreamDispatcher::CreateMessageStream(
+std::unique_ptr<MessageStream> MessageStreamDispatcher::CreateMessageStream(
     Uid uid, StreamId stream_id) {
   auto message_stream =
-      MakePtr<MessageStream>(protocol_context_, uid, stream_id);
+      make_unique<MessageStream>(protocol_context_, uid, stream_id);
   Tie(*message_stream, protocol_read_gate_);
   return message_stream;
 }
@@ -78,7 +78,7 @@ void MessageStreamDispatcher::OnStreamToClient(
       CreateMessageStream(message.uid, message.stream_id));
 
   // notify about new stream created
-  new_stream_event_.Emit(message.uid, stream_it->second);
+  new_stream_event_.Emit(message.uid, *stream_it->second);
 }
 
 }  // namespace ae

--- a/aether/client_messages/message_stream_dispatcher.h
+++ b/aether/client_messages/message_stream_dispatcher.h
@@ -20,6 +20,7 @@
 #include <map>
 
 #include "aether/uid.h"
+#include "aether/memory.h"
 #include "aether/ptr/ptr.h"
 #include "aether/events/events.h"
 #include "aether/events/event_subscription.h"
@@ -34,7 +35,7 @@
 namespace ae {
 class MessageStreamDispatcher {
  public:
-  using NewStreamEvent = Event<void(Uid uid, Ptr<MessageStream> stream)>;
+  using NewStreamEvent = Event<void(Uid uid, MessageStream& stream)>;
 
   explicit MessageStreamDispatcher(ByteStream& connection_stream);
 
@@ -44,7 +45,8 @@ class MessageStreamDispatcher {
   void CloseStream(Uid uid);
 
  private:
-  Ptr<MessageStream> CreateMessageStream(Uid uid, StreamId stream_id);
+  std::unique_ptr<MessageStream> CreateMessageStream(Uid uid,
+                                                     StreamId stream_id);
   void OnStreamToClient(
       MessageEventData<ClientSafeApi::StreamToClient> const& msg);
 
@@ -52,7 +54,7 @@ class MessageStreamDispatcher {
 
   ProtocolReadGate<ClientSafeApi> protocol_read_gate_;
   NewStreamEvent new_stream_event_;
-  std::map<Uid, Ptr<MessageStream>> streams_;
+  std::map<Uid, std::unique_ptr<MessageStream>> streams_;
 
   Subscription on_client_stream_subscription_;
 };

--- a/aether/client_messages/p2p_message_stream.cpp
+++ b/aether/client_messages/p2p_message_stream.cpp
@@ -25,7 +25,7 @@ P2pStream::P2pStream(ActionContext action_context, Ptr<Client> const& client,
       client_{client},
       destination_{destination},
       stream_id_{stream_id},
-      receive_client_connection_{client->client_connection()},
+      receive_client_connection_{&client->client_connection()},
       // TODO: add buffer config
       buffer_gate_{action_context, 20 * 1024},
       send_receive_gate_{WriteOnlyGate{}, ReadOnlyGate{action_context_}} {
@@ -40,12 +40,12 @@ P2pStream::P2pStream(ActionContext action_context, Ptr<Client> const& client,
 
 P2pStream::P2pStream(ActionContext action_context, Ptr<Client> const& client,
                      Uid destination, StreamId stream_id,
-                     Ptr<ByteStream> receive_stream)
+                     std::unique_ptr<ByteStream> receive_stream)
     : action_context_{action_context},
       client_{client},
       destination_{destination},
       stream_id_{stream_id},
-      receive_client_connection_{client->client_connection()},
+      receive_client_connection_{&client->client_connection()},
       // TODO: add buffer config
       buffer_gate_{action_context, 100},
       send_receive_gate_{WriteOnlyGate{}, ReadOnlyGate{action_context_}},
@@ -61,10 +61,10 @@ P2pStream::P2pStream(ActionContext action_context, Ptr<Client> const& client,
 }
 
 P2pStream::~P2pStream() {
-  if (receive_client_connection_) {
+  if (receive_client_connection_ != nullptr) {
     receive_client_connection_->CloseStream(destination_, stream_id_);
   }
-  if (send_client_connection_) {
+  if (send_client_connection_ != nullptr) {
     send_client_connection_->CloseStream(destination_, stream_id_);
   }
 }
@@ -80,7 +80,7 @@ void P2pStream::ConnectReceive() {
 }
 
 void P2pStream::ConnectSend() {
-  if (!send_client_connection_) {
+  if (send_client_connection_ == nullptr) {
     auto client_ptr = client_.Lock();
 
     // get destination client's cloud connection  to creat stream
@@ -88,11 +88,11 @@ void P2pStream::ConnectSend() {
         client_ptr->client_connection_manager()->GetClientConnection(
             destination_);
     get_client_connection_subscription_ =
-        get_client_connection_action->SubscribeOnResult(
-            [this](auto const& action) {
-              send_client_connection_ = action.client_cloud_connection();
-              TieSendStream(*send_client_connection_);
-            });
+        get_client_connection_action->SubscribeOnResult([this](auto& action) {
+          // FIXME: dangling pointer
+          send_client_connection_ = action.client_cloud_connection().get();
+          TieSendStream(*send_client_connection_);
+        });
     return;
   }
   TieSendStream(*send_client_connection_);

--- a/aether/client_messages/p2p_message_stream.h
+++ b/aether/client_messages/p2p_message_stream.h
@@ -20,8 +20,8 @@
 #include "aether/common.h"
 
 #include "aether/uid.h"
+#include "aether/memory.h"
 #include "aether/client.h"
-#include "aether/ptr/ptr.h"
 #include "aether/ptr/ptr_view.h"
 #include "aether/actions/action_context.h"
 
@@ -38,7 +38,7 @@ class P2pStream final : public ByteStream {
             Uid destination, StreamId stream_id);
   P2pStream(ActionContext action_context, Ptr<Client> const& client,
             Uid destination, StreamId stream_id,
-            Ptr<ByteStream> receive_stream);
+            std::unique_ptr<ByteStream> receive_stream);
 
   ~P2pStream() override;
 
@@ -61,13 +61,13 @@ class P2pStream final : public ByteStream {
   Uid destination_;
   StreamId stream_id_;
 
-  Ptr<ClientConnection> receive_client_connection_;
-  Ptr<ClientConnection> send_client_connection_;
+  ClientConnection* receive_client_connection_;
+  ClientConnection* send_client_connection_;
 
   BufferGate buffer_gate_;
   ParallelGate<WriteOnlyGate, ReadOnlyGate> send_receive_gate_;
-  Ptr<ByteStream> receive_stream_;
-  Ptr<ByteStream> send_stream_;
+  std::unique_ptr<ByteStream> receive_stream_;
+  std::unique_ptr<ByteStream> send_stream_;
 
   Subscription get_client_connection_subscription_;
 };

--- a/aether/client_messages/p2p_message_stream.h
+++ b/aether/client_messages/p2p_message_stream.h
@@ -61,8 +61,8 @@ class P2pStream final : public ByteStream {
   Uid destination_;
   StreamId stream_id_;
 
-  ClientConnection* receive_client_connection_;
-  ClientConnection* send_client_connection_;
+  Ptr<ClientConnection> receive_client_connection_;
+  Ptr<ClientConnection> send_client_connection_;
 
   BufferGate buffer_gate_;
   ParallelGate<WriteOnlyGate, ReadOnlyGate> send_receive_gate_;

--- a/aether/client_messages/p2p_safe_message_stream.cpp
+++ b/aether/client_messages/p2p_safe_message_stream.cpp
@@ -21,7 +21,7 @@
 namespace ae {
 P2pSafeStream::P2pSafeStream(ActionContext action_context,
                              SafeStreamConfig const& config,
-                             Ptr<P2pStream> base_stream)
+                             std::unique_ptr<P2pStream> base_stream)
     : sized_packet_gate_{},
       safe_stream_{action_context, config},
       base_stream_{std::move(base_stream)} {

--- a/aether/client_messages/p2p_safe_message_stream.h
+++ b/aether/client_messages/p2p_safe_message_stream.h
@@ -18,7 +18,7 @@
 #define AETHER_CLIENT_MESSAGES_P2P_SAFE_MESSAGE_STREAM_H_
 
 #include "aether/common.h"
-#include "aether/ptr/ptr.h"
+#include "aether/memory.h"
 #include "aether/actions/action_context.h"
 
 #include "aether/stream_api/istream.h"
@@ -33,7 +33,7 @@ namespace ae {
 class P2pSafeStream final : public ByteStream {
  public:
   P2pSafeStream(ActionContext action_context, SafeStreamConfig const& config,
-                Ptr<P2pStream> base_stream);
+                std::unique_ptr<P2pStream> base_stream);
 
   AE_CLASS_NO_COPY_MOVE(P2pSafeStream)
 
@@ -43,7 +43,7 @@ class P2pSafeStream final : public ByteStream {
  private:
   SizedPacketGate sized_packet_gate_;
   SafeStream safe_stream_;
-  Ptr<P2pStream> base_stream_;
+  std::unique_ptr<P2pStream> base_stream_;
 };
 
 }  // namespace ae

--- a/aether/crypto/async_crypto_provider.cpp
+++ b/aether/crypto/async_crypto_provider.cpp
@@ -28,50 +28,54 @@
 namespace ae {
 namespace _async_internal {
 template <typename KeyType>
-Ptr<IEncryptProvider> CreateEncryptImpl(
-    KeyType const&, Ptr<IAsyncKeyProvider> /* key_provider */) {
+std::unique_ptr<IEncryptProvider> CreateEncryptImpl(
+    KeyType const&, std::unique_ptr<IAsyncKeyProvider> /* key_provider */) {
   assert(false);
   return {};
 }
 
 template <typename KeyType>
-Ptr<IDecryptProvider> CreateDecryptImpl(
-    KeyType const&, Ptr<IAsyncKeyProvider> /* key_provider */) {
+std::unique_ptr<IDecryptProvider> CreateDecryptImpl(
+    KeyType const&, std::unique_ptr<IAsyncKeyProvider> /* key_provider */) {
   assert(false);
   return {};
 }
 
 #if AE_CRYPTO_ASYNC == AE_SODIUM_BOX_SEAL
 template <>
-Ptr<IEncryptProvider> CreateEncryptImpl(SodiumCurvePublicKey const&,
-                                        Ptr<IAsyncKeyProvider> key_provider) {
-  return MakePtr<SodiumAsyncEncryptProvider>(std::move(key_provider));
+std::unique_ptr<IEncryptProvider> CreateEncryptImpl(
+    SodiumCurvePublicKey const&,
+    std::unique_ptr<IAsyncKeyProvider> key_provider) {
+  return make_unique<SodiumAsyncEncryptProvider>(std::move(key_provider));
 }
 
 template <>
-Ptr<IDecryptProvider> CreateDecryptImpl(SodiumCurvePublicKey const&,
-                                        Ptr<IAsyncKeyProvider> key_provider) {
-  return MakePtr<SodiumAsyncDecryptProvider>(std::move(key_provider));
+std::unique_ptr<IDecryptProvider> CreateDecryptImpl(
+    SodiumCurvePublicKey const&,
+    std::unique_ptr<IAsyncKeyProvider> key_provider) {
+  return make_unique<SodiumAsyncDecryptProvider>(std::move(key_provider));
 }
 #endif
 
 #if AE_CRYPTO_ASYNC == AE_HYDRO_CRYPTO_PK
 template <>
-Ptr<IEncryptProvider> CreateEncryptImpl(HydrogenCurvePublicKey const&,
-                                        Ptr<IAsyncKeyProvider> key_provider) {
-  return MakePtr<HydroAsyncEncryptProvider>(std::move(key_provider));
+std::unique_ptr<IEncryptProvider> CreateEncryptImpl(
+    HydrogenCurvePublicKey const&,
+    std::unique_ptr<IAsyncKeyProvider> key_provider) {
+  return make_unique<HydroAsyncEncryptProvider>(std::move(key_provider));
 }
 
 template <>
-Ptr<IDecryptProvider> CreateDecryptImpl(HydrogenCurvePublicKey const&,
-                                        Ptr<IAsyncKeyProvider> key_provider) {
-  return MakePtr<HydroAsyncDecryptProvider>(std::move(key_provider));
+std::unique_ptr<IDecryptProvider> CreateDecryptImpl(
+    HydrogenCurvePublicKey const&,
+    std::unique_ptr<IAsyncKeyProvider> key_provider) {
+  return make_unique<HydroAsyncDecryptProvider>(std::move(key_provider));
 }
 #endif
 }  // namespace _async_internal
 
 AsyncEncryptProvider::AsyncEncryptProvider(
-    Ptr<IAsyncKeyProvider> key_provider) {
+    std::unique_ptr<IAsyncKeyProvider> key_provider) {
   auto pub_key = key_provider->PublicKey();
   impl_ = std::visit(
       [&](auto key_type) {
@@ -91,7 +95,7 @@ std::size_t AsyncEncryptProvider::EncryptOverhead() const {
 }
 
 AsyncDecryptProvider::AsyncDecryptProvider(
-    Ptr<IAsyncKeyProvider> key_provider) {
+    std::unique_ptr<IAsyncKeyProvider> key_provider) {
   auto pub_key = key_provider->PublicKey();
   impl_ = std::visit(
       [&](auto key_type) {

--- a/aether/crypto/async_crypto_provider.h
+++ b/aether/crypto/async_crypto_provider.h
@@ -17,7 +17,7 @@
 #ifndef AETHER_CRYPTO_ASYNC_CRYPTO_PROVIDER_H_
 #define AETHER_CRYPTO_ASYNC_CRYPTO_PROVIDER_H_
 
-#include "aether/ptr/ptr.h"
+#include "aether/memory.h"
 
 #include "aether/crypto/icrypto_provider.h"
 #include "aether/crypto/ikey_provider.h"
@@ -25,22 +25,24 @@
 namespace ae {
 class AsyncEncryptProvider : public IEncryptProvider {
  public:
-  explicit AsyncEncryptProvider(Ptr<IAsyncKeyProvider> key_provider);
+  explicit AsyncEncryptProvider(
+      std::unique_ptr<IAsyncKeyProvider> key_provider);
 
   DataBuffer Encrypt(DataBuffer const& data) override;
   std::size_t EncryptOverhead() const override;
 
  private:
-  Ptr<IEncryptProvider> impl_;
+  std::unique_ptr<IEncryptProvider> impl_;
 };
 
 class AsyncDecryptProvider : public IDecryptProvider {
  public:
-  explicit AsyncDecryptProvider(Ptr<IAsyncKeyProvider> key_provider);
+  explicit AsyncDecryptProvider(
+      std::unique_ptr<IAsyncKeyProvider> key_provider);
   DataBuffer Decrypt(DataBuffer const& data) override;
 
  private:
-  Ptr<IDecryptProvider> impl_;
+  std::unique_ptr<IDecryptProvider> impl_;
 };
 }  // namespace ae
 

--- a/aether/crypto/hydrogen/hydro_async_crypto_provider.cpp
+++ b/aether/crypto/hydrogen/hydro_async_crypto_provider.cpp
@@ -18,10 +18,10 @@
 
 #if AE_CRYPTO_ASYNC == AE_HYDRO_CRYPTO_PK
 
+#  include <vector>
 #  include <utility>
 #  include <cassert>
 #  include <algorithm>
-#  include <vector>
 
 #  include "aether/crypto/crypto_definitions.h"
 
@@ -82,7 +82,7 @@ inline std::vector<std::uint8_t> DecryptWithAsymmetric(
 }  // namespace _internal
 
 HydroAsyncEncryptProvider::HydroAsyncEncryptProvider(
-    Ptr<IAsyncKeyProvider> key_provider)
+    std::unique_ptr<IAsyncKeyProvider> key_provider)
     : key_provider_{std::move(key_provider)} {}
 
 DataBuffer HydroAsyncEncryptProvider::Encrypt(DataBuffer const& data) {
@@ -98,7 +98,7 @@ std::size_t HydroAsyncEncryptProvider::EncryptOverhead() const {
 }
 
 HydroAsyncDecryptProvider::HydroAsyncDecryptProvider(
-    Ptr<IAsyncKeyProvider> key_provider)
+    std::unique_ptr<IAsyncKeyProvider> key_provider)
     : key_provider_{std::move(key_provider)} {}
 
 DataBuffer HydroAsyncDecryptProvider::Decrypt(DataBuffer const& data) {

--- a/aether/crypto/hydrogen/hydro_async_crypto_provider.h
+++ b/aether/crypto/hydrogen/hydro_async_crypto_provider.h
@@ -21,7 +21,7 @@
 
 #if AE_CRYPTO_ASYNC == AE_HYDRO_CRYPTO_PK
 
-#  include "aether/ptr/ptr.h"
+#  include "aether/memory.h"
 
 #  include "aether/crypto/icrypto_provider.h"
 #  include "aether/crypto/ikey_provider.h"
@@ -29,23 +29,25 @@
 namespace ae {
 class HydroAsyncEncryptProvider : public IEncryptProvider {
  public:
-  explicit HydroAsyncEncryptProvider(Ptr<IAsyncKeyProvider> key_provider);
+  explicit HydroAsyncEncryptProvider(
+      std::unique_ptr<IAsyncKeyProvider> key_provider);
 
   DataBuffer Encrypt(DataBuffer const& data) override;
   std::size_t EncryptOverhead() const override;
 
  private:
-  Ptr<IAsyncKeyProvider> key_provider_;
+  std::unique_ptr<IAsyncKeyProvider> key_provider_;
 };
 
 class HydroAsyncDecryptProvider : public IDecryptProvider {
  public:
-  explicit HydroAsyncDecryptProvider(Ptr<IAsyncKeyProvider> key_provider);
+  explicit HydroAsyncDecryptProvider(
+      std::unique_ptr<IAsyncKeyProvider> key_provider);
 
   DataBuffer Decrypt(DataBuffer const& data) override;
 
  private:
-  Ptr<IAsyncKeyProvider> key_provider_;
+  std::unique_ptr<IAsyncKeyProvider> key_provider_;
 };
 
 }  // namespace ae

--- a/aether/crypto/hydrogen/hydro_sync_crypto_provider.cpp
+++ b/aether/crypto/hydrogen/hydro_sync_crypto_provider.cpp
@@ -58,7 +58,7 @@ inline std::vector<std::uint8_t> DecryptWithSymmetric(
 }  // namespace _internal
 
 HydroSyncEncryptProvider::HydroSyncEncryptProvider(
-    Ptr<ISyncKeyProvider> key_provider)
+    std::unique_ptr<ISyncKeyProvider> key_provider)
     : key_provider_{std::move(key_provider)} {}
 
 DataBuffer HydroSyncEncryptProvider::Encrypt(DataBuffer const& data) {
@@ -73,7 +73,7 @@ std::size_t HydroSyncEncryptProvider::EncryptOverhead() const {
 }
 
 HydroSyncDecryptProvider::HydroSyncDecryptProvider(
-    Ptr<ISyncKeyProvider> key_provider)
+    std::unique_ptr<ISyncKeyProvider> key_provider)
     : key_provider_{std::move(key_provider)} {}
 
 DataBuffer HydroSyncDecryptProvider::Decrypt(DataBuffer const& data) {

--- a/aether/crypto/hydrogen/hydro_sync_crypto_provider.h
+++ b/aether/crypto/hydrogen/hydro_sync_crypto_provider.h
@@ -21,7 +21,7 @@
 
 #if AE_CRYPTO_SYNC == AE_HYDRO_CRYPTO_SK
 
-#  include "aether/ptr/ptr.h"
+#  include "aether/memory.h"
 
 #  include "aether/crypto/icrypto_provider.h"
 #  include "aether/crypto/ikey_provider.h"
@@ -29,23 +29,25 @@
 namespace ae {
 class HydroSyncEncryptProvider : public IEncryptProvider {
  public:
-  explicit HydroSyncEncryptProvider(Ptr<ISyncKeyProvider> key_provider);
+  explicit HydroSyncEncryptProvider(
+      std::unique_ptr<ISyncKeyProvider> key_provider);
 
   DataBuffer Encrypt(DataBuffer const& data) override;
   std::size_t EncryptOverhead() const override;
 
  private:
-  Ptr<ISyncKeyProvider> key_provider_;
+  std::unique_ptr<ISyncKeyProvider> key_provider_;
 };
 
 class HydroSyncDecryptProvider : public IDecryptProvider {
  public:
-  explicit HydroSyncDecryptProvider(Ptr<ISyncKeyProvider> key_provider);
+  explicit HydroSyncDecryptProvider(
+      std::unique_ptr<ISyncKeyProvider> key_provider);
 
   DataBuffer Decrypt(DataBuffer const& data) override;
 
  private:
-  Ptr<ISyncKeyProvider> key_provider_;
+  std::unique_ptr<ISyncKeyProvider> key_provider_;
 };
 }  // namespace ae
 

--- a/aether/crypto/sodium/sodium_async_crypto_provider.cpp
+++ b/aether/crypto/sodium/sodium_async_crypto_provider.cpp
@@ -19,9 +19,9 @@
 
 #if AE_CRYPTO_ASYNC == AE_SODIUM_BOX_SEAL
 
+#  include <vector>
 #  include <cassert>
 #  include <utility>
-#  include <vector>
 
 namespace ae {
 namespace _internal {
@@ -54,7 +54,7 @@ std::vector<std::uint8_t> DecryptWithAsymmetric(
 }  // namespace _internal
 
 SodiumAsyncEncryptProvider::SodiumAsyncEncryptProvider(
-    Ptr<IAsyncKeyProvider> key_provider)
+    std::unique_ptr<IAsyncKeyProvider> key_provider)
     : key_provider_{std::move(key_provider)} {}
 
 DataBuffer SodiumAsyncEncryptProvider::Encrypt(DataBuffer const& data) {
@@ -70,7 +70,7 @@ std::size_t SodiumAsyncEncryptProvider::EncryptOverhead() const {
 }
 
 SodiumAsyncDecryptProvider::SodiumAsyncDecryptProvider(
-    Ptr<IAsyncKeyProvider> key_provider)
+    std::unique_ptr<IAsyncKeyProvider> key_provider)
     : key_provider_{std::move(key_provider)} {}
 
 DataBuffer SodiumAsyncDecryptProvider::Decrypt(DataBuffer const& data) {

--- a/aether/crypto/sodium/sodium_async_crypto_provider.h
+++ b/aether/crypto/sodium/sodium_async_crypto_provider.h
@@ -21,7 +21,7 @@
 
 #if AE_CRYPTO_ASYNC == AE_SODIUM_BOX_SEAL
 
-#  include "aether/ptr/ptr.h"
+#  include "aether/memory.h"
 
 #  include "aether/crypto/icrypto_provider.h"
 #  include "aether/crypto/ikey_provider.h"
@@ -29,23 +29,25 @@
 namespace ae {
 class SodiumAsyncEncryptProvider : public IEncryptProvider {
  public:
-  explicit SodiumAsyncEncryptProvider(Ptr<IAsyncKeyProvider> key_provider);
+  explicit SodiumAsyncEncryptProvider(
+      std::unique_ptr<IAsyncKeyProvider> key_provider);
 
   DataBuffer Encrypt(DataBuffer const& data) override;
   std::size_t EncryptOverhead() const override;
 
  private:
-  Ptr<IAsyncKeyProvider> key_provider_;
+  std::unique_ptr<IAsyncKeyProvider> key_provider_;
 };
 
 class SodiumAsyncDecryptProvider : public IDecryptProvider {
  public:
-  explicit SodiumAsyncDecryptProvider(Ptr<IAsyncKeyProvider> key_provider);
+  explicit SodiumAsyncDecryptProvider(
+      std::unique_ptr<IAsyncKeyProvider> key_provider);
 
   DataBuffer Decrypt(DataBuffer const& data) override;
 
  private:
-  Ptr<IAsyncKeyProvider> key_provider_;
+  std::unique_ptr<IAsyncKeyProvider> key_provider_;
 };
 }  // namespace ae
 #endif

--- a/aether/crypto/sodium/sodium_sync_crypto_provider.cpp
+++ b/aether/crypto/sodium/sodium_sync_crypto_provider.cpp
@@ -18,10 +18,10 @@
 
 #if AE_CRYPTO_SYNC == AE_CHACHA20_POLY1305
 
+#  include <vector>
 #  include <cassert>
 #  include <utility>
 #  include <algorithm>
-#  include <vector>
 
 #  include "aether/crypto/crypto_nonce.h"
 
@@ -42,8 +42,7 @@ inline DataBuffer EncryptWithSymmetric(SodiumChachaKey const& secret_key,
 
   assert(r == 0);
 
-  ciphertext.resize(static_cast<std::size_t>
-                   (ciphertext_len + nonce.size()));
+  ciphertext.resize(static_cast<std::size_t>(ciphertext_len + nonce.size()));
 
   // add nonce to the end of ciphertext
   std::copy(
@@ -80,7 +79,7 @@ inline DataBuffer DecryptWithSymmetric(SodiumChachaKey const& secret_key,
 }  // namespace _internal
 
 SodiumSyncEncryptProvider::SodiumSyncEncryptProvider(
-    Ptr<ISyncKeyProvider> key_provider)
+    std::unique_ptr<ISyncKeyProvider> key_provider)
     : key_provider_{std::move(key_provider)} {}
 
 DataBuffer SodiumSyncEncryptProvider::Encrypt(DataBuffer const& data) {
@@ -96,7 +95,7 @@ std::size_t SodiumSyncEncryptProvider::EncryptOverhead() const {
 }
 
 SodiumSyncDecryptProvider::SodiumSyncDecryptProvider(
-    Ptr<ISyncKeyProvider> key_provider)
+    std::unique_ptr<ISyncKeyProvider> key_provider)
     : key_provider_{std::move(key_provider)} {}
 
 DataBuffer SodiumSyncDecryptProvider::Decrypt(DataBuffer const& data) {

--- a/aether/crypto/sodium/sodium_sync_crypto_provider.h
+++ b/aether/crypto/sodium/sodium_sync_crypto_provider.h
@@ -21,7 +21,7 @@
 
 #if AE_CRYPTO_SYNC == AE_CHACHA20_POLY1305
 
-#  include "aether/ptr/ptr.h"
+#  include "aether/memory.h"
 
 #  include "aether/crypto/icrypto_provider.h"
 #  include "aether/crypto/ikey_provider.h"
@@ -29,23 +29,25 @@
 namespace ae {
 class SodiumSyncEncryptProvider : public IEncryptProvider {
  public:
-  explicit SodiumSyncEncryptProvider(Ptr<ISyncKeyProvider> key_provider);
+  explicit SodiumSyncEncryptProvider(
+      std::unique_ptr<ISyncKeyProvider> key_provider);
 
   DataBuffer Encrypt(DataBuffer const& data) override;
   std::size_t EncryptOverhead() const override;
 
  private:
-  Ptr<ISyncKeyProvider> key_provider_;
+  std::unique_ptr<ISyncKeyProvider> key_provider_;
 };
 
 class SodiumSyncDecryptProvider : public IDecryptProvider {
  public:
-  explicit SodiumSyncDecryptProvider(Ptr<ISyncKeyProvider> key_provider);
+  explicit SodiumSyncDecryptProvider(
+      std::unique_ptr<ISyncKeyProvider> key_provider);
 
   DataBuffer Decrypt(DataBuffer const& data) override;
 
  private:
-  Ptr<ISyncKeyProvider> key_provider_;
+  std::unique_ptr<ISyncKeyProvider> key_provider_;
 };
 }  // namespace ae
 

--- a/aether/crypto/sync_crypto_provider.h
+++ b/aether/crypto/sync_crypto_provider.h
@@ -17,7 +17,7 @@
 #ifndef AETHER_CRYPTO_SYNC_CRYPTO_PROVIDER_H_
 #define AETHER_CRYPTO_SYNC_CRYPTO_PROVIDER_H_
 
-#include "aether/ptr/ptr.h"
+#include "aether/memory.h"
 
 #include "aether/crypto/icrypto_provider.h"
 #include "aether/crypto/ikey_provider.h"
@@ -25,22 +25,22 @@
 namespace ae {
 class SyncEncryptProvider : public IEncryptProvider {
  public:
-  explicit SyncEncryptProvider(Ptr<ISyncKeyProvider> key_provider);
+  explicit SyncEncryptProvider(std::unique_ptr<ISyncKeyProvider> key_provider);
 
   DataBuffer Encrypt(DataBuffer const& data) override;
   std::size_t EncryptOverhead() const override;
 
  private:
-  Ptr<IEncryptProvider> impl_;
+  std::unique_ptr<IEncryptProvider> impl_;
 };
 
 class SyncDecryptProvider : public IDecryptProvider {
  public:
-  explicit SyncDecryptProvider(Ptr<ISyncKeyProvider> key_provider);
+  explicit SyncDecryptProvider(std::unique_ptr<ISyncKeyProvider> key_provider);
   DataBuffer Decrypt(DataBuffer const& data) override;
 
  private:
-  Ptr<IDecryptProvider> impl_;
+  std::unique_ptr<IDecryptProvider> impl_;
 };
 }  // namespace ae
 

--- a/aether/events/events.h
+++ b/aether/events/events.h
@@ -154,8 +154,8 @@ class EventSubscriber {
   [[nodiscard]] auto Subscribe(TInstance& instance,
                                MethodPtr<Method> const& method) {
     static_assert(
-        std::is_same_v<TSignature,
-                       typename FunctionSignature<decltype(Method)>::Signature>,
+        Event<TSignature>::template kIsInvocable<
+            Delegate<typename FunctionSignature<decltype(Method)>::Signature>>,
         "Method must have the same signature");
     auto subscription =
         MakeRcPtr<SubscriptionManage>(SubscriptionManage{true, false});

--- a/aether/memory.h
+++ b/aether/memory.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Aethernet Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AETHER_MEMORY_H_
+#define AETHER_MEMORY_H_
+
+#include <memory>
+
+namespace ae {
+using std::make_unique;
+
+template <template <typename...> typename T, typename... TArgs>
+auto make_unique(TArgs&&... args) {
+  using Deduced = decltype(T(std::forward<TArgs>(args)...));
+  return make_unique<Deduced>(std::forward<TArgs>(args)...);
+}
+
+}  // namespace ae
+
+#endif  // AETHER_MEMORY_H_

--- a/aether/ptr/ptr_management.h
+++ b/aether/ptr/ptr_management.h
@@ -87,11 +87,15 @@ struct RefCounterVisitor {
       return false;
     }
     auto const& refs = obj.ptr_storage_->ref_counters;
+    if (refs.main_refs == 0) {
+      return false;
+    }
 
     auto [it, _] = obj_map.emplace(
         obj_ptr, std::make_unique<RefTree>(obj_ptr, refs.main_refs));
     auto& ref_counter = *it->second;
     ref_counter.reachable_ref_count++;
+    assert(ref_counter.reachable_ref_count <= ref_counter.ref_count);
     children.insert(&ref_counter);
 
     auto next_visitor =

--- a/aether/server_list/list_policy.h
+++ b/aether/server_list/list_policy.h
@@ -20,6 +20,7 @@
 #include "aether/common.h"
 
 #include "aether/ptr/ptr.h"
+#include "aether/ptr/ptr_view.h"
 
 #include "aether/server.h"
 #include "aether/channel.h"
@@ -27,17 +28,17 @@
 namespace ae {
 class ServerListItem {
  public:
-  ServerListItem(Ptr<Server> server, Ptr<Channel> channel)
-      : server_{std::move(server)}, channel_{std::move(channel)} {}
+  ServerListItem(Ptr<Server> const& server, Ptr<Channel> const& channel)
+      : server_{server}, channel_{channel} {}
 
   AE_CLASS_COPY_MOVE(ServerListItem)
 
-  Ptr<Server> const& server() const { return server_; }
-  Ptr<Channel> const& channel() const { return channel_; }
+  Ptr<Server> server() const { return server_.Lock(); }
+  Ptr<Channel> channel() const { return channel_.Lock(); }
 
  private:
-  Ptr<Server> server_;
-  Ptr<Channel> channel_;
+  PtrView<Server> server_;
+  PtrView<Channel> channel_;
 };
 
 // Policy interface to make server list

--- a/aether/server_list/no_filter_server_list_policy.cpp
+++ b/aether/server_list/no_filter_server_list_policy.cpp
@@ -16,19 +16,30 @@
 
 #include "aether/server_list/no_filter_server_list_policy.h"
 
+#include <cassert>
+
 #include "aether/server.h"
 
 namespace ae {
 bool NoFilterServerListPolicy::Preferred(ServerListItem const& left,
                                          ServerListItem const& right) const {
   // simple ordering comparison
-  if (left.server() == right.server()) {
-    for (auto const& i : left.server()->channels) {
-      if (i.get() == left.channel().get()) {
+  auto left_server = left.server();
+  auto left_channel = left.channel();
+  auto right_server = right.server();
+  auto right_channel = right.channel();
+  assert(left_server);
+  assert(left_channel);
+  assert(right_server);
+  assert(right_channel);
+
+  if (left_server == right_server) {
+    for (auto const& i : left_server->channels) {
+      if (i.get() == left_channel.get()) {
         // left first
         return true;
       }
-      if (i.get() == right.channel().get()) {
+      if (i.get() == right_channel.get()) {
         // right first
         break;
       }
@@ -36,7 +47,7 @@ bool NoFilterServerListPolicy::Preferred(ServerListItem const& left,
     return false;
   }
 
-  return left.server()->server_id < right.server()->server_id;
+  return left_server->server_id < right_server->server_id;
 }
 
 bool NoFilterServerListPolicy::Filter(ServerListItem const& /* info */) const {

--- a/aether/server_list/server_list.h
+++ b/aether/server_list/server_list.h
@@ -19,12 +19,13 @@
 
 #include <vector>
 
-#include "aether/ptr/ptr.h"
+#include "aether/memory.h"
+#include "aether/ptr/ptr_view.h"
+#include "aether/obj/obj_ptr.h"
 
 #include "aether/server_list/list_policy.h"
 
 namespace ae {
-class Aether;
 class Cloud;
 
 class ServerList {
@@ -55,7 +56,8 @@ class ServerList {
     container_type::iterator item_;
   };
 
-  ServerList(Ptr<ServerListPolicy> policy, Ptr<Cloud> cloud);
+  ServerList(std::unique_ptr<ServerListPolicy> policy,
+             ObjPtr<Cloud> const& cloud);
 
   void Init();
   bool End() const;
@@ -65,8 +67,8 @@ class ServerList {
  private:
   void BuildList();
 
-  Ptr<ServerListPolicy> policy_;
-  Ptr<Cloud> cloud_;
+  std::unique_ptr<ServerListPolicy> policy_;
+  PtrView<Cloud> cloud_;
 
   container_type server_list_;
   container_type::iterator iter_;

--- a/aether/stream_api/crypto_stream.cpp
+++ b/aether/stream_api/crypto_stream.cpp
@@ -20,8 +20,8 @@
 
 namespace ae {
 
-CryptoGate::CryptoGate(Ptr<IEncryptProvider> crypto_encrypt,
-                       Ptr<IDecryptProvider> crypto_decrypt)
+CryptoGate::CryptoGate(std::unique_ptr<IEncryptProvider> crypto_encrypt,
+                       std::unique_ptr<IDecryptProvider> crypto_decrypt)
     : crypto_encrypt_{std::move(crypto_encrypt)},
       crypto_decrypt_{std::move(crypto_decrypt)} {}
 

--- a/aether/stream_api/crypto_stream.h
+++ b/aether/stream_api/crypto_stream.h
@@ -17,7 +17,7 @@
 #ifndef AETHER_STREAM_API_CRYPTO_STREAM_H_
 #define AETHER_STREAM_API_CRYPTO_STREAM_H_
 
-#include "aether/ptr/ptr.h"
+#include "aether/memory.h"
 
 #include "aether/stream_api/istream.h"
 
@@ -28,8 +28,8 @@ class CryptoGate final : public ByteGate {
   friend class CryptoStream;
 
  public:
-  CryptoGate(Ptr<IEncryptProvider> crypto_encrypt,
-             Ptr<IDecryptProvider> crypto_decrypt);
+  CryptoGate(std::unique_ptr<IEncryptProvider> crypto_encrypt,
+             std::unique_ptr<IDecryptProvider> crypto_decrypt);
 
   ActionView<StreamWriteAction> Write(DataBuffer&& buffer,
                                       TimePoint current_time) override;
@@ -41,8 +41,8 @@ class CryptoGate final : public ByteGate {
  private:
   void OnOutData(DataBuffer const& buffer);
 
-  Ptr<IEncryptProvider> crypto_encrypt_;
-  Ptr<IDecryptProvider> crypto_decrypt_;
+  std::unique_ptr<IEncryptProvider> crypto_encrypt_;
+  std::unique_ptr<IDecryptProvider> crypto_decrypt_;
 };
 }  // namespace ae
 

--- a/aether/stream_api/transport_write_gate.cpp
+++ b/aether/stream_api/transport_write_gate.cpp
@@ -65,8 +65,8 @@ void TransportWriteGate::TransportStreamWriteAction::Stop() {
 }
 
 TransportWriteGate::TransportWriteGate(ActionContext action_context,
-                                       Ptr<ITransport> transport)
-    : transport_{std::move(transport)},
+                                       ITransport& transport)
+    : transport_{&transport},
       stream_info_{},
       transport_connection_subscription_{
           transport_->ConnectionSuccess().Subscribe(

--- a/aether/stream_api/transport_write_gate.h
+++ b/aether/stream_api/transport_write_gate.h
@@ -18,7 +18,7 @@
 #define AETHER_STREAM_API_TRANSPORT_WRITE_GATE_H_
 
 #include "aether/common.h"
-#include "aether/ptr/ptr.h"
+#include "aether/memory.h"
 #include "aether/actions/action_list.h"
 #include "aether/actions/action_context.h"
 #include "aether/transport/itransport.h"
@@ -43,7 +43,7 @@ class TransportWriteGate final : public ByteIGate {
   };
 
  public:
-  TransportWriteGate(ActionContext action_context, Ptr<ITransport> transport);
+  TransportWriteGate(ActionContext action_context, ITransport& transport);
   ~TransportWriteGate() override;
 
   AE_CLASS_NO_COPY_MOVE(TransportWriteGate)
@@ -59,7 +59,7 @@ class TransportWriteGate final : public ByteIGate {
   void GateUpdate();
   void ReceiveData(DataBuffer const& data, TimePoint current_time);
 
-  Ptr<ITransport> transport_;
+  ITransport* transport_;
 
   StreamInfo stream_info_;
 

--- a/aether/transport/actions/channel_connection_action.h
+++ b/aether/transport/actions/channel_connection_action.h
@@ -19,7 +19,7 @@
 
 #include <cstddef>
 
-#include "aether/ptr/ptr.h"
+#include "aether/memory.h"
 #include "aether/address.h"
 #include "aether/actions/action.h"
 
@@ -43,7 +43,7 @@ class ChannelConnectionAction : public Action<ChannelConnectionAction> {
  public:
   using Action::Action;
 
-  virtual Ptr<ITransport> transport() const = 0;
+  virtual std::unique_ptr<ITransport> transport() = 0;
   virtual ConnectionInfo connection_info() const = 0;
 };
 }  // namespace ae

--- a/aether/transport/actions/ip_channel_connection.cpp
+++ b/aether/transport/actions/ip_channel_connection.cpp
@@ -62,8 +62,8 @@ TimePoint IpAddressChannelConnectionAction::Update(TimePoint current_time) {
   return current_time;
 }
 
-Ptr<ITransport> IpAddressChannelConnectionAction::transport() const {
-  return transport_;
+std::unique_ptr<ITransport> IpAddressChannelConnectionAction::transport() {
+  return std::move(transport_);
 }
 
 ConnectionInfo IpAddressChannelConnectionAction::connection_info() const {
@@ -78,7 +78,7 @@ void IpAddressChannelConnectionAction::TryConnect(
 
   subscriptions_.Push(
       transport_create_action->SubscribeOnResult(
-          [this](auto const& action) { TransportCreated(action.transport()); }),
+          [this](auto& action) { TransportCreated(action.transport()); }),
       transport_create_action->SubscribeOnError([this](auto const&) {
         AE_TELED_ERROR("Transport create failed");
         state_.Set(State::Failed);
@@ -86,7 +86,7 @@ void IpAddressChannelConnectionAction::TryConnect(
 }
 
 void IpAddressChannelConnectionAction::TransportCreated(
-    Ptr<ITransport> transport) {
+    std::unique_ptr<ITransport> transport) {
   transport_ = std::move(transport);
 
   auto connection_info = transport_->GetConnectionInfo();

--- a/aether/transport/actions/ip_channel_connection.h
+++ b/aether/transport/actions/ip_channel_connection.h
@@ -17,6 +17,7 @@
 #ifndef AETHER_TRANSPORT_ACTIONS_IP_CHANNEL_CONNECTION_H_
 #define AETHER_TRANSPORT_ACTIONS_IP_CHANNEL_CONNECTION_H_
 
+#include "aether/memory.h"
 #include "aether/address.h"
 #include "aether/state_machine.h"
 #include "aether/actions/action_context.h"
@@ -45,17 +46,17 @@ class IpAddressChannelConnectionAction : public ChannelConnectionAction {
 
   TimePoint Update(TimePoint current_time) override;
 
-  Ptr<ITransport> transport() const override;
+  std::unique_ptr<ITransport> transport() override;
   ConnectionInfo connection_info() const override;
 
  private:
   void TryConnect(TimePoint current_time);
-  void TransportCreated(Ptr<ITransport> transport);
+  void TransportCreated(std::unique_ptr<ITransport> transport);
 
   IpAddressPortProtocol ip_address_port_protocol_;
   Adapter& adapter_;
 
-  Ptr<ITransport> transport_;
+  std::unique_ptr<ITransport> transport_;
   ConnectionInfo connection_info_;
   StateMachine<State> state_;
 

--- a/aether/transport/actions/name_address_channel_connection.cpp
+++ b/aether/transport/actions/name_address_channel_connection.cpp
@@ -71,8 +71,8 @@ TimePoint NameAddressChannelConnectionAction::Update(TimePoint current_time) {
   return current_time;
 }
 
-Ptr<ITransport> NameAddressChannelConnectionAction::transport() const {
-  return transport_;
+std::unique_ptr<ITransport> NameAddressChannelConnectionAction::transport() {
+  return std::move(transport_);
 }
 
 ConnectionInfo NameAddressChannelConnectionAction::connection_info() const {
@@ -81,7 +81,8 @@ ConnectionInfo NameAddressChannelConnectionAction::connection_info() const {
 
 void NameAddressChannelConnectionAction::NameResolve(
     TimePoint /* current_time */) {
-  auto& resolver_action = dns_resolver_->Resolve(name_address_);
+  auto resolver_ptr = dns_resolver_.Lock();
+  auto& resolver_action = resolver_ptr->Resolve(name_address_);
   dns_resolve_subscriptions_.Push(
       resolver_action
           .SubscribeOnResult([this](auto const& action) {

--- a/aether/transport/actions/name_address_channel_connection.h
+++ b/aether/transport/actions/name_address_channel_connection.h
@@ -24,8 +24,10 @@
 #  include <vector>
 #  include <optional>
 
+#  include "aether/memory.h"
 #  include "aether/address.h"
 #  include "aether/ptr/ptr.h"
+#  include "aether/ptr/ptr_view.h"
 #  include "aether/actions/action_context.h"
 #  include "aether/events/multi_subscription.h"
 
@@ -57,7 +59,7 @@ class NameAddressChannelConnectionAction : public ChannelConnectionAction {
   ~NameAddressChannelConnectionAction() override;
 
   TimePoint Update(TimePoint current_time) override;
-  Ptr<ITransport> transport() const override;
+  std::unique_ptr<ITransport> transport() override;
   ConnectionInfo connection_info() const override;
 
  private:
@@ -65,11 +67,11 @@ class NameAddressChannelConnectionAction : public ChannelConnectionAction {
   void TryConnection(TimePoint current_time);
 
   NameAddress name_address_;
-  Ptr<DnsResolver> dns_resolver_;
+  PtrView<DnsResolver> dns_resolver_;
   ActionContext action_context_;
   PtrView<Adapter> adapter_;
 
-  Ptr<ITransport> transport_;
+  std::unique_ptr<ITransport> transport_;
   ConnectionInfo connection_info_;
 
   StateMachine<State> state_;

--- a/aether/transport/server/server_channel_stream.cpp
+++ b/aether/transport/server/server_channel_stream.cpp
@@ -63,16 +63,16 @@ ServerChannelStream::ServerChannelStream(ObjPtr<Aether> const& aether,
           channel_->address)} {
   connection_subscriptions_.Push(
       connection_action_->SubscribeOnResult(
-          [this](auto const& action) { OnConnected(action); }),
+          [this](auto& action) { OnConnected(action); }),
       connection_action_->SubscribeOnError(
           [this](auto const&) { OnConnectedFailed(); }),
       connection_action_->FinishedEvent().Subscribe(
           [this]() { connection_action_.Reset(); }));
 }
 
-void ServerChannelStream::OnConnected(
-    ChannelConnectionAction const& connection) {
-  transport_write_gate_.emplace(action_context_, connection.transport());
+void ServerChannelStream::OnConnected(ChannelConnectionAction& connection) {
+  transport_ = connection.transport();
+  transport_write_gate_.emplace(action_context_, *transport_);
   Tie(buffer_gate_, *transport_write_gate_);
 }
 

--- a/aether/transport/server/server_channel_stream.h
+++ b/aether/transport/server/server_channel_stream.h
@@ -51,7 +51,7 @@ class ServerChannelStream final : public ByteStream {
   void LinkOut(OutGate& /* out */) override { assert(false); }
 
  private:
-  void OnConnected(ChannelConnectionAction const& connection);
+  void OnConnected(ChannelConnectionAction& connection);
   void OnConnectedFailed();
 
   ActionContext action_context_;
@@ -59,6 +59,7 @@ class ServerChannelStream final : public ByteStream {
   Channel::ptr channel_;
 
   BufferGate buffer_gate_;
+  std::unique_ptr<ITransport> transport_;
   std::optional<TransportWriteGate> transport_write_gate_;
 
   Ptr<class ChannelConnectionAction> connection_action_;

--- a/aether/type_traits.h
+++ b/aether/type_traits.h
@@ -114,6 +114,9 @@ struct IsOptional : std::false_type {};
 template <typename T>
 struct IsOptional<std::optional<T>> : std::true_type {};
 
+/**
+ * \brief Type has std::optional like interface, looks like optional.
+ */
 template <typename T, typename _ = void>
 struct IsOptionalLike : std::false_type {};
 
@@ -121,8 +124,24 @@ template <typename T>
 struct IsOptionalLike<
     T, std::void_t<decltype(!!std::declval<T>()), decltype(*std::declval<T>())>>
     : std::true_type {};
-}  // namespace ae
 
+/**
+ * \brief Type has a smart pointer like interface, looks like pointer.
+ */
+template <typename T, typename Enable = void>
+struct IsPointerLike : std::false_type {};
+
+template <typename T>
+struct IsPointerLike<T,
+                     std::void_t<decltype(static_cast<bool>(std::declval<T>())),
+                                 decltype(*std::declval<T>()),
+                                 decltype(std::declval<T>().operator->()),
+                                 decltype(std::declval<T>().get())>>
+    : std::true_type {};
+
+/**
+ * \brief Type is functor object with given signature
+ */
 template <typename T, typename TSignature, typename _ = void>
 struct IsFunctor : std::false_type {};
 
@@ -131,6 +150,9 @@ struct IsFunctor<T, TRes(TArgs...),
                  std::enable_if_t<std::is_invocable_r_v<TRes, T, TArgs...>>>
     : std::true_type {};
 
+/**
+ * \brief Type is function pointer
+ */
 template <typename TFuncPtr, typename T, typename _ = void>
 struct IsFunctionPtr : std::false_type {};
 
@@ -161,6 +183,9 @@ template <typename TClass, typename TRes, typename... TArgs>
 auto GetSignatureImpl(TRes (TClass::*)(TArgs...))
     -> FunctionSignatureImpl<TRes(TArgs...)>;
 
+/**
+ * \brief Get a signature of functor object, or function pointer.
+ */
 template <typename TFunc, typename FuncSignatureImp =
                               decltype(GetSignatureImpl(std::declval<TFunc>()))>
 struct FunctionSignature {
@@ -168,17 +193,26 @@ struct FunctionSignature {
   using FuncPtr = typename FuncSignatureImp::FuncPtr;
 };
 
+/**
+ * \brief Get I'th argument in template args list.
+ */
 template <std::size_t I, auto... args>
 constexpr auto ArgAt() {
   return std::get<I>(std::forward_as_tuple(args...));
 }
 
+/**
+ * \brief Get I'th argument in args list.
+ */
 template <std::size_t I, typename... TArgs>
 constexpr auto&& ArgAt(TArgs&&... args) {
   return std::forward<std::tuple_element_t<I, std::tuple<TArgs...>>>(
       std::get<I>(std::forward_as_tuple(args...)));
 }
 
+/**
+ * \brief Get I'th type in template type list.
+ */
 template <std::size_t I, typename... Ts>
 constexpr auto TypeAt() -> std::tuple_element_t<I, std::tuple<Ts...>>;
 
@@ -197,5 +231,7 @@ template <typename T, typename U>
 constexpr auto& StaticConst(U const& u) {
   return static_cast<std::add_const_t<std::remove_reference_t<T>>&>(u);
 }
+
+}  // namespace ae
 
 #endif  // AETHER_TYPE_TRAITS_H_ */

--- a/examples/benches/send_message_delays/main.cpp
+++ b/examples/benches/send_message_delays/main.cpp
@@ -126,13 +126,14 @@ class TestSendMessageDelaysAction : public Action<TestSendMessageDelaysAction> {
         std::chrono::milliseconds{200},
     };
 
-    auto sender = MakePtr<Sender>(ActionContext{*aether_->action_processor},
-                                  client_sender_, client_receiver_->uid(),
-                                  safe_stream_config);
-    auto receiver = MakePtr<Receiver>(ActionContext{*aether_->action_processor},
-                                      client_receiver_, safe_stream_config);
+    auto sender = make_unique<Sender>(ActionContext{*aether_->action_processor},
+                                      client_sender_, client_receiver_->uid(),
+                                      safe_stream_config);
+    auto receiver =
+        make_unique<Receiver>(ActionContext{*aether_->action_processor},
+                              client_receiver_, safe_stream_config);
 
-    send_message_delays_manager_ = MakePtr<SendMessageDelaysManager>(
+    send_message_delays_manager_ = make_unique<SendMessageDelaysManager>(
         ActionContext{*aether_->action_processor}, std::move(sender),
         std::move(receiver));
 
@@ -180,7 +181,7 @@ class TestSendMessageDelaysAction : public Action<TestSendMessageDelaysAction> {
   std::ostream& write_results_stream_;
   Client::ptr client_sender_;
   Client::ptr client_receiver_;
-  Ptr<SendMessageDelaysManager> send_message_delays_manager_;
+  std::unique_ptr<SendMessageDelaysManager> send_message_delays_manager_;
 
   BarrierEvent<void, 2> clients_registered_event_;
   MultiSubscription registration_subscriptions_;

--- a/examples/benches/send_message_delays/receiver.h
+++ b/examples/benches/send_message_delays/receiver.h
@@ -17,6 +17,7 @@
 #ifndef EXAMPLES_BENCHES_RECEIVER_H_
 #define EXAMPLES_BENCHES_RECEIVER_H_
 
+#include "aether/memory.h"
 #include "aether/client.h"
 #include "aether/actions/action_context.h"
 #include "aether/events/event_subscription.h"
@@ -53,11 +54,11 @@ class Receiver {
   SafeStreamConfig safe_stream_config_;
 
   ProtocolContext protocol_context_;
-  Ptr<ClientConnection> connection_stream_;
-  Ptr<ProtocolReadGate<BenchDelaysApi>> protocol_read_gate_;
-  Ptr<ByteStream> receive_message_stream_;
+  Ptr<ClientConnection> client_connection_;
+  std::unique_ptr<ProtocolReadGate<BenchDelaysApi>> protocol_read_gate_;
+  std::unique_ptr<ByteStream> receive_message_stream_;
 
-  Ptr<ITimedReceiver> receiver_action_;
+  std::unique_ptr<ITimedReceiver> receiver_action_;
 
   Subscription message_stream_subscription_;
   MultiSubscription action_subscriptions_;

--- a/examples/benches/send_message_delays/send_message_delays_manager.h
+++ b/examples/benches/send_message_delays/send_message_delays_manager.h
@@ -60,8 +60,8 @@ class SendMessageDelaysManager {
     };
 
    public:
-    TestAction(ActionContext action_context, Ptr<Sender> sender,
-               Ptr<Receiver> receiver, SendMessageDelaysManagerConfig config);
+    TestAction(ActionContext action_context, Sender& sender, Receiver& receiver,
+               SendMessageDelaysManagerConfig config);
 
     TimePoint Update(TimePoint current_time) override;
 
@@ -86,11 +86,11 @@ class SendMessageDelaysManager {
     void TestResult(TimeTable const& sended_table,
                     TimeTable const& received_table);
 
-    Ptr<Sender> sender_;
-    Ptr<Receiver> receiver_;
+    Sender* sender_;
+    Receiver* receiver_;
     SendMessageDelaysManagerConfig config_;
 
-    Ptr<BarrierEvent<TimeTable, 2>> res_event_;
+    std::unique_ptr<BarrierEvent<TimeTable, 2>> res_event_;
     StateMachine<State> state_;
     Subscription state_changed_subscription_;
     MultiSubscription error_subscriptions_;
@@ -101,17 +101,18 @@ class SendMessageDelaysManager {
   };
 
  public:
-  SendMessageDelaysManager(ActionContext action_context, Ptr<Sender> sender,
-                           Ptr<Receiver> receiver);
+  SendMessageDelaysManager(ActionContext action_context,
+                           std::unique_ptr<Sender> sender,
+                           std::unique_ptr<Receiver> receiver);
 
   ActionView<TestAction> Test(SendMessageDelaysManagerConfig config);
 
  private:
   ActionContext action_context_;
-  Ptr<Sender> sender_;
-  Ptr<Receiver> receiver_;
+  std::unique_ptr<Sender> sender_;
+  std::unique_ptr<Receiver> receiver_;
 
-  Ptr<TestAction> test_action_;
+  std::unique_ptr<TestAction> test_action_;
   MultiSubscription test_action_subscription_;
 };
 }  // namespace ae::bench

--- a/examples/benches/send_message_delays/sender.cpp
+++ b/examples/benches/send_message_delays/sender.cpp
@@ -36,21 +36,21 @@ Sender::Sender(ActionContext action_context, Client::ptr client,
 void Sender::ConnectP2pStream() {
   AE_TELED_DEBUG("Sender::ConnectP2pStream()");
 
-  send_message_stream_ = MakePtr<P2pStream>(action_context_, client_,
-                                            destination_uid_, StreamId{0});
+  send_message_stream_ = make_unique<P2pStream>(action_context_, client_,
+                                                destination_uid_, StreamId{0});
 }
 
 void Sender::ConnectP2pSafeStream() {
   AE_TELED_DEBUG("Sender::ConnectP2pSafeStream()");
-  send_message_stream_ =
-      MakePtr<P2pSafeStream>(action_context_, safe_stream_config_,
-                             MakePtr<P2pStream>(action_context_, client_,
-                                                destination_uid_, StreamId{1}));
+  send_message_stream_ = make_unique<P2pSafeStream>(
+      action_context_, safe_stream_config_,
+      make_unique<P2pStream>(action_context_, client_, destination_uid_,
+                             StreamId{1}));
 }
 
 void Sender::Disconnect() {
   AE_TELED_DEBUG("Sender::Disconnect()");
-  send_message_stream_.Reset();
+  send_message_stream_.reset();
 }
 
 ActionView<ITimedSender> Sender::WarmUp(std::size_t message_count,
@@ -95,12 +95,12 @@ ActionView<ITimedSender> Sender::Send1500Bytes(std::size_t message_count,
 template <typename TMessage>
 void Sender::CreateBenchAction(std::size_t message_count,
                                Duration min_send_interval) {
-  sender_action_ = MakePtr<TimedSender<BenchDelaysApi, TMessage>>(
-      action_context_, protocol_context_, send_message_stream_, message_count,
+  sender_action_ = make_unique<TimedSender<BenchDelaysApi, TMessage>>(
+      action_context_, protocol_context_, *send_message_stream_, message_count,
       min_send_interval);
 
   action_subscriptions_.Push(sender_action_->FinishedEvent().Subscribe(
-      [this]() { sender_action_.Reset(); }));
+      [this]() { sender_action_.reset(); }));
 }
 
 }  // namespace ae::bench

--- a/examples/benches/send_message_delays/sender.h
+++ b/examples/benches/send_message_delays/sender.h
@@ -18,6 +18,7 @@
 #define EXAMPLES_BENCHES_SEND_MESSAGE_DELAYS_SENDER_H_
 
 #include "aether/uid.h"
+#include "aether/memory.h"
 #include "aether/client.h"
 #include "aether/events/multi_subscription.h"
 #include "aether/actions/action_view.h"
@@ -57,10 +58,10 @@ class Sender {
   Client::ptr client_;
   Uid destination_uid_;
   SafeStreamConfig safe_stream_config_;
-  Ptr<ByteStream> send_message_stream_;
+  std::unique_ptr<ByteStream> send_message_stream_;
   ProtocolContext protocol_context_;
 
-  Ptr<ITimedSender> sender_action_;
+  std::unique_ptr<ITimedSender> sender_action_;
 
   MultiSubscription action_subscriptions_;
 };

--- a/examples/benches/send_message_delays/timed_sender.h
+++ b/examples/benches/send_message_delays/timed_sender.h
@@ -59,11 +59,11 @@ class TimedSender : public ITimedSender {
 
  public:
   TimedSender(ActionContext action_context, ProtocolContext& protocol_context,
-              Ptr<ByteStream> stream, std::size_t message_count,
+              ByteStream& stream, std::size_t message_count,
               Duration min_send_interval)
       : ITimedSender{action_context},
         protocol_context_{protocol_context},
-        stream_{std::move(stream)},
+        stream_{&stream},
         message_count_{message_count},
         min_send_interval_{min_send_interval},
         state_{State::kSend},
@@ -153,7 +153,7 @@ class TimedSender : public ITimedSender {
   }
 
   ProtocolContext& protocol_context_;
-  Ptr<ByteStream> stream_;
+  ByteStream* stream_;
   std::size_t message_count_;
 
   Duration min_send_interval_;

--- a/examples/benches/send_messages_bandwidth/common/message_sender.h
+++ b/examples/benches/send_messages_bandwidth/common/message_sender.h
@@ -46,12 +46,11 @@ class MessageSender : public Action<MessageSender<TApi, TMessage>> {
 
  public:
   MessageSender(ActionContext action_context, ProtocolContext& protocol_context,
-                TApi&& api_class, Ptr<ByteStream> stream,
-                std::size_t send_count)
+                TApi&& api_class, ByteStream& stream, std::size_t send_count)
       : SelfAction{action_context},
         protocol_context_{protocol_context},
         api_class_{std::move(api_class)},
-        stream_{std::move(stream)},
+        stream_{&stream},
         send_count_{send_count},
         state_{State::kSending},
         state_changed_{state_.changed_event().Subscribe(
@@ -141,7 +140,7 @@ class MessageSender : public Action<MessageSender<TApi, TMessage>> {
 
   ProtocolContext& protocol_context_;
   TApi api_class_;
-  Ptr<ByteStream> stream_;
+  ByteStream* stream_;
   std::size_t send_count_;
   Duration send_duration_;
 

--- a/examples/benches/send_messages_bandwidth/common/receiver.h
+++ b/examples/benches/send_messages_bandwidth/common/receiver.h
@@ -20,6 +20,7 @@
 #include <optional>
 
 #include "aether/client.h"
+#include "aether/memory.h"
 #include "aether/actions/action_context.h"
 #include "aether/events/events.h"
 #include "aether/events/event_subscription.h"
@@ -56,24 +57,25 @@ class Receiver {
 
  private:
   template <typename T>
-  Ptr<MessageReceiver<T>> CreateTestAction(std::size_t message_count);
+  std::unique_ptr<MessageReceiver<T>> CreateTestAction(
+      std::size_t message_count);
 
   ActionContext action_context_;
   Client::ptr client_;
   ProtocolContext protocol_context_;
 
   Ptr<ClientConnection> client_connection_;
-  Ptr<ByteStream> message_stream_;
-  Ptr<ProtocolReadGate<BandwidthApi>> protocol_read_gate_;
+  std::unique_ptr<ByteStream> message_stream_;
+  std::unique_ptr<ProtocolReadGate<BandwidthApi>> protocol_read_gate_;
 
   std::optional<ReceiverSyncAction> sync_action_;
 
-  Ptr<MessageReceiver<BandwidthApi::WarmUp>> warm_up_;
-  Ptr<MessageReceiver<BandwidthApi::OneByte>> one_byte_;
-  Ptr<MessageReceiver<BandwidthApi::TenBytes>> ten_bytes_;
-  Ptr<MessageReceiver<BandwidthApi::HundredBytes>> hundred_bytes_;
-  Ptr<MessageReceiver<BandwidthApi::ThousandBytes>> thousand_bytes_;
-  Ptr<MessageReceiver<BandwidthApi::VarMessageSize>> variable_size_;
+  std::unique_ptr<MessageReceiver<BandwidthApi::WarmUp>> warm_up_;
+  std::unique_ptr<MessageReceiver<BandwidthApi::OneByte>> one_byte_;
+  std::unique_ptr<MessageReceiver<BandwidthApi::TenBytes>> ten_bytes_;
+  std::unique_ptr<MessageReceiver<BandwidthApi::HundredBytes>> hundred_bytes_;
+  std::unique_ptr<MessageReceiver<BandwidthApi::ThousandBytes>> thousand_bytes_;
+  std::unique_ptr<MessageReceiver<BandwidthApi::VarMessageSize>> variable_size_;
 
   Event<void(Bandwidth const&)> test_finished_event_;
   Event<void()> handshake_made_;

--- a/examples/benches/send_messages_bandwidth/common/receiver_sync.cpp
+++ b/examples/benches/send_messages_bandwidth/common/receiver_sync.cpp
@@ -27,10 +27,10 @@
 namespace ae::bench {
 ReceiverSyncAction::ReceiverSyncAction(ActionContext action_context,
                                        ProtocolContext& protocol_context,
-                                       Ptr<ByteStream> stream)
+                                       ByteStream& stream)
     : Action{action_context},
       protocol_context_{protocol_context},
-      stream_{std::move(stream)},
+      stream_{&stream},
       state_{State::kWait},
       state_changed_subscription_{state_.changed_event().Subscribe(
           [this](auto) { Action::Trigger(); })},

--- a/examples/benches/send_messages_bandwidth/common/receiver_sync.h
+++ b/examples/benches/send_messages_bandwidth/common/receiver_sync.h
@@ -40,7 +40,7 @@ class ReceiverSyncAction : public Action<ReceiverSyncAction> {
 
  public:
   ReceiverSyncAction(ActionContext action_context,
-                     ProtocolContext& protocol_context, Ptr<ByteStream> stream);
+                     ProtocolContext& protocol_context, ByteStream& stream);
 
   TimePoint Update(TimePoint current_time) override;
 
@@ -49,7 +49,7 @@ class ReceiverSyncAction : public Action<ReceiverSyncAction> {
   TimePoint CheckTimeout(TimePoint current_time);
 
   ProtocolContext& protocol_context_;
-  Ptr<ByteStream> stream_;
+  ByteStream* stream_;
 
   StateMachine<State> state_;
   TimePoint start_time_;

--- a/examples/benches/send_messages_bandwidth/common/sender.h
+++ b/examples/benches/send_messages_bandwidth/common/sender.h
@@ -20,6 +20,7 @@
 #include <optional>
 
 #include "aether/client.h"
+#include "aether/memory.h"
 #include "aether/actions/action_context.h"
 #include "aether/events/events.h"
 #include "aether/events/multi_subscription.h"
@@ -55,7 +56,7 @@ class Sender {
 
  private:
   template <typename T>
-  Ptr<MessageSender<BandwidthApi, T>> CreateTestAction(
+  std::unique_ptr<MessageSender<BandwidthApi, T>> CreateTestAction(
       std::size_t message_count);
 
   ActionContext action_context_;
@@ -68,17 +69,21 @@ class Sender {
   Event<void()> sync_made_;
   Event<void()> error_event_;
 
-  Ptr<ByteStream> message_stream_;
+  std::unique_ptr<ByteStream> message_stream_;
   ProtocolReadGate<BandwidthApi> response_read_;
 
   std::optional<SenderSyncAction> sync_action_;
 
-  Ptr<MessageSender<BandwidthApi, BandwidthApi::WarmUp>> warm_up_;
-  Ptr<MessageSender<BandwidthApi, BandwidthApi::OneByte>> one_byte_;
-  Ptr<MessageSender<BandwidthApi, BandwidthApi::TenBytes>> ten_bytes_;
-  Ptr<MessageSender<BandwidthApi, BandwidthApi::HundredBytes>> hundred_bytes_;
-  Ptr<MessageSender<BandwidthApi, BandwidthApi::ThousandBytes>> thousand_bytes_;
-  Ptr<MessageSender<BandwidthApi, BandwidthApi::VarMessageSize>> variable_size_;
+  std::unique_ptr<MessageSender<BandwidthApi, BandwidthApi::WarmUp>> warm_up_;
+  std::unique_ptr<MessageSender<BandwidthApi, BandwidthApi::OneByte>> one_byte_;
+  std::unique_ptr<MessageSender<BandwidthApi, BandwidthApi::TenBytes>>
+      ten_bytes_;
+  std::unique_ptr<MessageSender<BandwidthApi, BandwidthApi::HundredBytes>>
+      hundred_bytes_;
+  std::unique_ptr<MessageSender<BandwidthApi, BandwidthApi::ThousandBytes>>
+      thousand_bytes_;
+  std::unique_ptr<MessageSender<BandwidthApi, BandwidthApi::VarMessageSize>>
+      variable_size_;
 
   MultiSubscription test_subscriptions_;
 };

--- a/examples/benches/send_messages_bandwidth/common/sender_sync.cpp
+++ b/examples/benches/send_messages_bandwidth/common/sender_sync.cpp
@@ -27,10 +27,10 @@
 namespace ae::bench {
 SenderSyncAction::SenderSyncAction(ActionContext action_context,
                                    ProtocolContext& protocol_context,
-                                   Ptr<ByteStream> stream)
+                                   ByteStream& stream)
     : Action{action_context},
       protocol_context_{protocol_context},
-      stream_{std::move(stream)},
+      stream_{&stream},
       state_{State::kSendSync},
       current_repeat_{},
       state_changed_subscription_{state_.changed_event().Subscribe(

--- a/examples/benches/send_messages_bandwidth/common/sender_sync.h
+++ b/examples/benches/send_messages_bandwidth/common/sender_sync.h
@@ -42,7 +42,7 @@ class SenderSyncAction : public Action<SenderSyncAction> {
  public:
   explicit SenderSyncAction(ActionContext action_context,
                             ProtocolContext& protocol_context,
-                            Ptr<ByteStream> stream);
+                            ByteStream& stream);
 
   TimePoint Update(TimePoint current_time) override;
 
@@ -51,7 +51,7 @@ class SenderSyncAction : public Action<SenderSyncAction> {
   TimePoint CheckInterval(TimePoint current_time);
 
   ProtocolContext& protocol_context_;
-  Ptr<ByteStream> stream_;
+  ByteStream* stream_;
 
   StateMachine<State> state_;
   std::size_t current_repeat_;

--- a/examples/benches/send_messages_bandwidth/common/test_action.h
+++ b/examples/benches/send_messages_bandwidth/common/test_action.h
@@ -55,10 +55,10 @@ class TestAction : public Action<TestAction<TAgent>> {
   };
 
  public:
-  explicit TestAction(ActionContext action_context, Ptr<TAgent> agent,
+  explicit TestAction(ActionContext action_context, TAgent& agent,
                       std::size_t test_message_count)
       : SelfAction{action_context},
-        agent_{std::move(agent)},
+        agent_{&agent},
         test_message_count_{test_message_count},
         state_{State::kConnect},
         state_changed_{state_.changed_event().Subscribe(
@@ -202,7 +202,7 @@ class TestAction : public Action<TestAction<TAgent>> {
         }); */
   }
 
-  Ptr<TAgent> agent_;
+  TAgent* agent_;
   std::size_t test_message_count_;
   StateMachine<State> state_;
 

--- a/examples/benches/send_messages_bandwidth/receiver/main.cpp
+++ b/examples/benches/send_messages_bandwidth/receiver/main.cpp
@@ -65,7 +65,7 @@ int test_receiver_bandwidth() {
   }
 
   auto action_context = ActionContext{*aether_app->aether()->action_processor};
-  auto receiver = MakePtr<Receiver>(action_context, client);
+  auto receiver = Receiver{action_context, client};
 
   auto test_action =
       TestAction<Receiver>(action_context, receiver, std::size_t{10000});

--- a/examples/benches/send_messages_bandwidth/sender/main.cpp
+++ b/examples/benches/send_messages_bandwidth/sender/main.cpp
@@ -68,7 +68,7 @@ int test_sender_bandwidth(Uid receiver_uid) {
   }
 
   auto action_context = ActionContext{*aether_app->aether()->action_processor};
-  auto sender = MakePtr<Sender>(action_context, client, receiver_uid);
+  auto sender = Sender{action_context, client, receiver_uid};
 
   auto test_action =
       TestAction<Sender>{action_context, sender, std::size_t{10000}};

--- a/examples/key_led/config/key_led_config.ini
+++ b/examples/key_led/config/key_led_config.ini
@@ -4,26 +4,21 @@ wifiPass = Test123
 sodiumKey = 4F202A94AB729FE9B381613AE77A8A7D89EDAB9299C3320D1A0B994BA710CCEB
 hydrogenKey = 883B4D7E0FB04A38CA12B3A451B00942048858263EE6E6D61150F2EF15F40343
 parentsNum = 1
-serversNum = 4
+serversNum = 3
 [ParentID1]
 uid = 3ac931653d37497087a6fa4ee27744e4
 clientsNum = 2
 [ServerID1]
 ipAddressType = kIpAddress
-ipAddress = 127.0.0.1
+ipAddress = 34.60.244.148
 ipPort = 9010
 ipProtocol = kTcp
 [ServerID2]
-ipAddressType = kIpAddress
-ipAddress = 35.224.1.127
-ipPort = 9010
-ipProtocol = kTcp
-[ServerID3]
 ipAddressType = kUrlAddress
 ipAddress = registration.aethernet.io
 ipPort = 9010
 ipProtocol = kTcp
-[ServerID4]
+[ServerID3]
 ipAddressType = kIpAddress
 ipAddress = fe80::215:5dff:fe34:8347
 ipPort = 9010

--- a/examples/registered/config/registered_config.ini
+++ b/examples/registered/config/registered_config.ini
@@ -4,7 +4,7 @@ wifiPass = Test123
 sodiumKey = 4F202A94AB729FE9B381613AE77A8A7D89EDAB9299C3320D1A0B994BA710CCEB
 hydrogenKey = 883B4D7E0FB04A38CA12B3A451B00942048858263EE6E6D61150F2EF15F40343
 parentsNum = 2
-serversNum = 4
+serversNum = 2
 [ParentID1]
 uid = 3ac931653d37497087a6fa4ee27744e4
 clientsNum = 2
@@ -12,21 +12,11 @@ clientsNum = 2
 uid = 3ac931653d37497087a6fa4ee27744e4
 clientsNum = 2
 [ServerID1]
-ipAddressType = kIpAddress
-ipAddress = 127.0.0.1
-ipPort = 9010
-ipProtocol = kTcp
-[ServerID2]
-ipAddressType = kIpAddress
-ipAddress = 35.224.1.127
-ipPort = 9010
-ipProtocol = kTcp
-[ServerID3]
 ipAddressType = kUrlAddress
 ipAddress = registration.aethernet.io
 ipPort = 9010
 ipProtocol = kTcp
-[ServerID4]
+[ServerID2]
 ipAddressType = kIpAddress
 ipAddress = fe80::215:5dff:fe34:8347
 ipPort = 9010

--- a/tests/test-stream/stream-api/test_stream_api.cpp
+++ b/tests/test-stream/stream-api/test_stream_api.cpp
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+#include <unity.h>
+
 #include <chrono>
+
 #include "aether/common.h"
+#include "aether/memory.h"
 #include "aether/transport/data_buffer.h"
-#include "unity.h"
 
 #include "aether/actions/action_context.h"
 #include "aether/port/tele_init.h"

--- a/tests/test-stream/templated-streams/test_templated_streams.cpp
+++ b/tests/test-stream/templated-streams/test_templated_streams.cpp
@@ -16,7 +16,7 @@
 
 #include "unity.h"
 
-#include "aether/ptr/ptr.h"
+#include "aether/memory.h"
 #include "aether/actions/action_processor.h"
 #include "aether/actions/action_context.h"
 
@@ -103,7 +103,8 @@ void test_StringIntGate() {
   DataBuffer written_data;
   int read_data;
 
-  auto write_gate = MakePtr<MockWriteGate>(ac, static_cast<std::size_t>(1000));
+  auto write_gate =
+      make_unique<MockWriteGate>(ac, static_cast<std::size_t>(1000));
   auto _0 = write_gate->on_write_event().Subscribe(
       [&](auto data, auto /* time */) { written_data = std::move(data); });
 

--- a/tools/registrator/registrator_action.h
+++ b/tools/registrator/registrator_action.h
@@ -17,6 +17,7 @@
 #ifndef TOOLS_REGISTRATOR_REGISTRATOR_ACTION_H_
 #define TOOLS_REGISTRATOR_REGISTRATOR_ACTION_H_
 
+#include "aether/memory.h"
 #include "aether/aether_app.h"
 #include "aether/client_messages/p2p_safe_message_stream.h"
 
@@ -59,10 +60,8 @@ class RegistratorAction : public Action<RegistratorAction> {
   RegistratorConfig registrator_config_;
 
   std::vector<std::string> messages_;
-  std::vector<ae::Ptr<ae::P2pSafeStream>> sender_streams_{};
+  std::vector<std::unique_ptr<P2pSafeStream>> sender_streams_;
 
-  Client::ptr sender_;
-  Ptr<ByteStream> sender_stream_;
   std::size_t clients_registered_{0};
   std::size_t receive_count_{0};
   std::size_t confirm_count_{0};


### PR DESCRIPTION
additional to #79 

replace most use of Ptr<T> with std::unique_ptr or references.
Fix memory leaks.