### PR TITLE
105 multithreaded telemetry

### DIFF
--- a/aether/packed_int.h
+++ b/aether/packed_int.h
@@ -362,6 +362,13 @@ class numeric_limits<ae::Packed<T, Min, MinMaxVal>> {
   static constexpr T min() { return T{0}; }
   static constexpr T max() { return ae::Packed<T, Min, MinMaxVal>::kUpper; }
 };
+
+template <typename T, typename Min, Min MinMaxVal>
+struct hash<ae::Packed<T, Min, MinMaxVal>> {
+  std::size_t operator()(ae::Packed<T, Min, MinMaxVal> const& packed) const {
+    return static_cast<std::size_t>(static_cast<T>(packed));
+  }
+};
 }  // namespace std
 
 #endif  // AETHER_PACKED_INT_H_ */

--- a/aether/tele/traps/io_stream_traps.h
+++ b/aether/tele/traps/io_stream_traps.h
@@ -17,6 +17,7 @@
 #ifndef AETHER_TELE_TRAPS_IO_STREAM_TRAPS_H_
 #define AETHER_TELE_TRAPS_IO_STREAM_TRAPS_H_
 
+#include <mutex>
 #include <cstdint>
 #include <iostream>
 #include <ostream>
@@ -42,10 +43,16 @@ struct Metric {
 
 struct IoStreamTrap {
   struct MetricsStream {
+    MetricsStream(std::uint32_t index,
+                  std::unordered_map<std::uint32_t, Metric>& metrics_);
+    MetricsStream(MetricsStream&& other) noexcept;
+    ~MetricsStream();
+
     void add_count(std::uint32_t count = 1);
     void add_duration(std::uint32_t duration);
 
-    Metric& metric_;
+    std::uint32_t index_;
+    std::unordered_map<std::uint32_t, Metric>& metrics_;
   };
 
   struct LogStream {
@@ -94,9 +101,11 @@ struct IoStreamTrap {
   LogStream log_stream(Declaration const& decl);
   MetricsStream metric_stream(Declaration const& decl);
   EnvStream env_stream();
+  std::mutex& sync();
 
+  std::mutex sync_lock_;
   std::ostream& stream_;
-  std::unordered_map<std::size_t, Metric> metrics_;
+  std::unordered_map<std::uint32_t, Metric> metrics_;
 };
 
 }  // namespace ae::tele

--- a/aether/tele/traps/null_traps.h
+++ b/aether/tele/traps/null_traps.h
@@ -61,6 +61,14 @@ struct NullTrap {
 
   EnvStream env_stream() { return {}; }
 
+  struct NullLock {
+    void lock() {}
+    void unlock() {}
+    bool try_lock() { return true; }
+  };
+
+  NullLock sync() { return {}; }
+
   AE_REFLECT()
 };
 }  // namespace ae::tele

--- a/tests/test-tele/test-tele.cpp
+++ b/tests/test-tele/test-tele.cpp
@@ -55,6 +55,7 @@
 #include "aether/tele/configs/config_provider.h"
 
 #include "aether/tele/traps/proxy_trap.h"
+#include "aether/tele/traps/null_traps.h"
 #include "aether/tele/traps/io_stream_traps.h"
 #include "aether/tele/traps/statistics_trap.h"
 
@@ -175,6 +176,7 @@ struct TeleTrap {
   MetricStream metric_stream(ae::tele::Declaration decl_) {
     return {metric_data_[decl_.index]};
   }
+  NullTrap::NullLock sync() { return {}; }
 };
 
 template <bool Count = true, bool Time = true, bool Index = true,
@@ -227,7 +229,7 @@ void test_TeleConfigurations() {
               Sink::Instance(), TestTag, Level::kDebug, __FILE__, __LINE__,
               "message {}",     12};
 
-      TEST_ASSERT_EQUAL(16, sizeof(t));
+      TEST_ASSERT_EQUAL(24, sizeof(t));
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     TEST_ASSERT_EQUAL(1, tele_trap->metric_data_.size());
@@ -262,7 +264,7 @@ void test_TeleConfigurations() {
               Sink::Instance(), TestTag, Level::kDebug, __FILE__, __LINE__,
               "message {}",     12};
 
-      TEST_ASSERT_EQUAL(16, sizeof(t));
+      TEST_ASSERT_EQUAL(24, sizeof(t));
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     TEST_ASSERT_EQUAL(1, tele_trap->metric_data_.size());
@@ -340,7 +342,7 @@ void test_TeleConfigurations() {
               Sink::Instance(), TestTag, Level::kDebug, __FILE__, __LINE__,
               "message {}",     12};
 
-      TEST_ASSERT_EQUAL(2, sizeof(t));
+      TEST_ASSERT_EQUAL(3, sizeof(t));
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 


### PR DESCRIPTION
closes #105

Add a simple mutex based synchronization in telemetry.
Traps provide a sync object and collector uses it on each trap's stream method call.