### PR TITLE
142 add a utm source to tele

### DIFF
--- a/aether/CMakeLists.txt
+++ b/aether/CMakeLists.txt
@@ -20,6 +20,7 @@ option(AE_NO_STRIP_ALL "Do not apply --strip_all, useful for bloaty and similar 
 
 option(AE_DISTILLATION "Build aether in distillation mode" OFF)
 
+set(UTM_ID "0" CACHE STRING "User Tracking Measurement ID, must be a uint32 value")
 set(USER_CONFIG "" CACHE PATH "Path to user provided configuration header file")
 set(FS_INIT "" CACHE PATH "Path to user provided saved state header file")
 
@@ -344,6 +345,8 @@ if (GIT_VERSION)
   target_compile_definitions(${TARGET_NAME} PUBLIC "AE_GIT_VERSION=\"${GIT_VERSION}\"")
 endif()
 target_compile_definitions(${TARGET_NAME} PUBLIC "AE_PROJECT_VERSION=\"${AE_PROJECT_VERSION}\"")
+
+target_compile_definitions(${TARGET_NAME} PUBLIC "UTM_ID=${UTM_ID}")
 
 if (NOT "${USER_CONFIG}" STREQUAL "")
   target_compile_definitions(${TARGET_NAME} PUBLIC "USER_CONFIG=\"${USER_CONFIG}\"")

--- a/aether/tele/configs/config_provider.h
+++ b/aether/tele/configs/config_provider.h
@@ -82,7 +82,7 @@ struct ConfigProvider {
 
   template <bool compiler = true, bool platform_type = true,
             bool compilation_options = true, bool library_version = true,
-            bool api_version = true, bool cpu_type = true,
+            bool api_version = true, bool cpu_type = true, bool utm_id = true,
             bool custom_data = true>
   struct EnvConfig {
     static constexpr bool kCompiler{compiler};
@@ -91,6 +91,7 @@ struct ConfigProvider {
     static constexpr bool kLibraryVersion{library_version};
     static constexpr bool kApiVersion{api_version};
     static constexpr bool kCpuType{cpu_type};
+    static constexpr bool kUtmId{utm_id};
     static constexpr bool kCustomData{custom_data};
   };
 
@@ -137,7 +138,7 @@ struct ConfigProvider {
       EnvConfig<AE_TELE_COMPILATION_INFO != 0, AE_TELE_COMPILATION_INFO != 0,
                 AE_TELE_COMPILATION_INFO != 0, AE_TELE_COMPILATION_INFO != 0,
                 AE_TELE_COMPILATION_INFO != 0, AE_TELE_COMPILATION_INFO != 0,
-                AE_TELE_RUNTIME_INFO>;
+                AE_TELE_COMPILATION_INFO != 0, AE_TELE_RUNTIME_INFO>;
 };
 }  // namespace ae::tele
 

--- a/aether/tele/defines.h
+++ b/aether/tele/defines.h
@@ -28,12 +28,16 @@
 #  error "Include tele.h instead"
 #endif
 
+#ifndef UTM_ID
+#  define UTM_ID 0
+#endif
+
 namespace ae::tele {
 using ae::tele::EnvTele;
 using ae::tele::Tele;
 }  // namespace ae::tele
 
-/// A special tag for telemetry debug debug
+// A special tag for telemetry debug debug
 
 AE_TELE_MODULE(MLog, AE_LOG_MODULE);
 AE_TAG_INDEXED(kLog, MLog, AE_LOG_MODULE)
@@ -65,7 +69,7 @@ AE_TAG_INDEXED(kLog, MLog, AE_LOG_MODULE)
 // Log environment data
 #define AE_TELE_ENV(...)                                                      \
   [[maybe_unused]] ::ae::tele::EnvTele<TELE_SINK> AE_UNIQUE_NAME(TELE_ENV_) { \
-    TELE_SINK::Instance() __VA_ARGS__                                         \
+    TELE_SINK::Instance(), UTM_ID __VA_ARGS__                                 \
   }
 
 #endif  // AETHER_TELE_DEFINES_H_ */

--- a/aether/tele/env_collectors.h
+++ b/aether/tele/env_collectors.h
@@ -99,7 +99,8 @@ struct EnvTele {
 
   template <typename... TValues>
   constexpr explicit EnvTele(
-      Sink& sink, [[maybe_unused]] std::pair<std::size_t, TValues>&&... args) {
+      Sink& sink, [[maybe_unused]] std::uint32_t utm_id,
+      [[maybe_unused]] std::pair<std::size_t, TValues>&&... args) {
     auto stream = sink.trap()->env_stream();
     if constexpr (SinkConfig::kPlatformType) {
       stream.platform_type(PlatformType());
@@ -122,6 +123,9 @@ struct EnvTele {
     if constexpr (SinkConfig::kCpuType) {
       stream.cpu_type(CpuType());
       stream.endianness(static_cast<uint8_t>(PlatformEndianness()));
+    }
+    if constexpr (SinkConfig::kUtmId) {
+      stream.utmid(utm_id);
     }
 
     if constexpr (SinkConfig::kCustomData) {

--- a/aether/tele/traps/io_stream_traps.cpp
+++ b/aether/tele/traps/io_stream_traps.cpp
@@ -152,12 +152,15 @@ void IoStreamTrap::EnvStream::api_version(char const* api_version) {
 void IoStreamTrap::EnvStream::cpu_type(char const* cpu_type) {
   stream_ << "CPU type:" << cpu_type << '\n';
 }
-void IoStreamTrap::EnvStream::endianness(uint8_t endianness) {
+void IoStreamTrap::EnvStream::endianness(std::uint8_t endianness) {
   stream_ << "Endianness:"
-          << (endianness == static_cast<uint8_t>(AE_LITTLE_ENDIAN)
+          << (endianness == static_cast<std::uint8_t>(AE_LITTLE_ENDIAN)
                   ? "LittleEndian"
                   : "BigEndian")
           << '\n';
+}
+void IoStreamTrap::EnvStream::utmid(std::uint32_t utm_id) {
+  stream_ << "UTM ID:" << utm_id << '\n';
 }
 
 IoStreamTrap::EnvStream IoStreamTrap::env_stream() {

--- a/aether/tele/traps/io_stream_traps.h
+++ b/aether/tele/traps/io_stream_traps.h
@@ -90,7 +90,8 @@ struct IoStreamTrap {
     void library_version(char const* library_version);
     void api_version(char const* api_version);
     void cpu_type(char const* cpu_type);
-    void endianness(uint8_t endianness);
+    void endianness(std::uint8_t endianness);
+    void utmid(std::uint32_t utm_id);
   };
 
   // list of known declarations

--- a/aether/tele/traps/null_traps.h
+++ b/aether/tele/traps/null_traps.h
@@ -56,7 +56,8 @@ struct NullTrap {
     void library_version(char const* /* library_version */) {}
     void api_version(char const* /* api_version */) {}
     void cpu_type(char const* /* cpu_type */) {}
-    void endianness(uint8_t /* endianness */) {}
+    void endianness(std::uint8_t /* endianness */) {}
+    void utmid(std::uint32_t /* utm_id */) {}
   };
 
   EnvStream env_stream() { return {}; }

--- a/aether/tele/traps/proxy_trap.h
+++ b/aether/tele/traps/proxy_trap.h
@@ -139,9 +139,13 @@ class ProxyTrap {
       stream1_.cpu_type(cpu_type);
       stream2_.cpu_type(cpu_type);
     }
-    void endianness(uint8_t endianness) {
+    void endianness(std::uint8_t endianness) {
       stream1_.endianness(endianness);
       stream2_.endianness(endianness);
+    }
+    void utmid(std::uint32_t utm_id) {
+      stream1_.utmid(utm_id);
+      stream2_.utmid(utm_id);
     }
   };
 

--- a/aether/tele/traps/statistics_trap.cpp
+++ b/aether/tele/traps/statistics_trap.cpp
@@ -224,12 +224,14 @@ void StatisticsTrap::EnvStream::library_version(char const* library_version) {
 void StatisticsTrap::EnvStream::api_version(char const* api_version) {
   env_store.api_version = api_version;
 }
-
 void StatisticsTrap::EnvStream::cpu_type(char const* cpu_type) {
   env_store.cpu_type = cpu_type;
 }
-void StatisticsTrap::EnvStream::endianness(uint8_t endianness) {
+void StatisticsTrap::EnvStream::endianness(std::uint8_t endianness) {
   env_store.endianness = endianness;
+}
+void StatisticsTrap::EnvStream::utmid(std::uint32_t utm_id) {
+  env_store.utm_id = utm_id;
 }
 
 StatisticsTrap::StatisticsTrap() = default;

--- a/aether/tele/traps/statistics_trap.h
+++ b/aether/tele/traps/statistics_trap.h
@@ -57,6 +57,9 @@ struct MetricsStore {
     PackedValue max_duration;
     PackedValue sum_duration;
     PackedValue min_duration;
+
+    AE_REFLECT_MEMBERS(invocations_count, max_duration, sum_duration,
+                       min_duration)
   };
 
   using MetricsMap = std::map<PackedIndex, Metric>;
@@ -84,49 +87,15 @@ struct EnvStore {
   std::string api_version;
   std::string cpu_type;
   std::uint8_t endianness;
+  std::uint32_t utm_id;
   std::vector<std::pair<PackedIndex, std::string>> compile_options;
+
+  AE_REFLECT_MEMBERS(platform_type, platform_version, compiler,
+                     compiler_version, library_version, api_version, cpu_type,
+                     endianness, utm_id, compile_options)
 };
 }  // namespace statistics
 }  // namespace ae::tele
-namespace ae {
-
-template <typename T>
-class omstream;
-template <typename T>
-class imstream;
-
-template <typename Ob>
-omstream<Ob>& operator<<(omstream<Ob>& s,
-                         const tele::statistics::MetricsStore::Metric& v) {
-  s << v.invocations_count << v.max_duration << v.sum_duration
-    << v.min_duration;
-  return s;
-}
-
-template <typename Ib>
-imstream<Ib>& operator>>(imstream<Ib>& s,
-                         tele::statistics::MetricsStore::Metric& v) {
-  s >> v.invocations_count >> v.max_duration >> v.sum_duration >>
-      v.min_duration;
-  return s;
-}
-
-template <typename Ob>
-omstream<Ob>& operator<<(omstream<Ob>& s, tele::statistics::EnvStore const& v) {
-  s << v.platform_type << v.platform_version << v.compiler << v.compiler_version
-    << v.library_version << v.api_version << v.cpu_type << v.endianness
-    << v.compile_options;
-  return s;
-}
-
-template <typename Ib>
-imstream<Ib>& operator>>(imstream<Ib>& s, tele::statistics::EnvStore& v) {
-  s >> v.platform_type >> v.platform_version >> v.compiler >>
-      v.compiler_version >> v.library_version >> v.api_version >> v.cpu_type >>
-      v.endianness >> v.compile_options;
-  return s;
-}
-}  // namespace ae
 
 namespace ae::tele {
 namespace statistics {
@@ -276,7 +245,8 @@ class StatisticsTrap {
     void library_version(char const* library_version);
     void api_version(char const* api_version);
     void cpu_type(char const* cpu_type);
-    void endianness(uint8_t endianness);
+    void endianness(std::uint8_t endianness);
+    void utmid(std::uint32_t utm_id);
 
     EnvStore& env_store;
   };


### PR DESCRIPTION
closes #142 

Add an UTM_ID tag in AE_TELE_ENV after all compile options and cpu architecture.
It prints only once on application start but stored separately from other telemetry.