### PR TITLE
Make some stack friendly

### DIFF
--- a/aether/events/delegate.h
+++ b/aether/events/delegate.h
@@ -70,7 +70,7 @@ class Delegate;
  */
 template <typename TRet, typename... TArgs>
 class Delegate<TRet(TArgs...)> {
-  using VirtualCallFunc = TRet (*)(void* instance, TArgs...);
+  using VirtualCallFunc = TRet (*)(void* instance, TArgs&&...);
 
  public:
   Delegate() = default;
@@ -125,33 +125,29 @@ class Delegate<TRet(TArgs...)> {
   AE_CLASS_COPY_MOVE(Delegate)
 
   constexpr TRet operator()(TArgs... args) const noexcept {
-    return Invoke(std::forward<TArgs>(args)...);
-  }
-
- private:
-  constexpr TRet Invoke(TArgs... args) const noexcept {
     return v_call_func_(instance_, std::forward<TArgs>(args)...);
   }
 
+ private:
   template <TRet (*func_pointer)(TArgs...)>
-  static TRet CallFunctionPointer(void* /*instance*/, TArgs... args) {
+  static TRet CallFunctionPointer(void* /*instance*/, TArgs&&... args) {
     return func_pointer(std::forward<TArgs>(args)...);
   }
 
   template <typename TFunctor>
-  static TRet CallFunctor(void* instance, TArgs... args) {
+  static TRet CallFunctor(void* instance, TArgs&&... args) {
     auto* functor_instance = static_cast<TFunctor*>(instance);
     return functor_instance->operator()(std::forward<TArgs>(args)...);
   }
 
   template <typename TClass, TRet (TClass::*Method)(TArgs...)>
-  static TRet CallClassMember(void* instance, TArgs... args) {
+  static TRet CallClassMember(void* instance, TArgs&&... args) {
     auto* class_instance = static_cast<TClass*>(instance);
     return (class_instance->*Method)(std::forward<TArgs>(args)...);
   }
 
   template <typename TClass, TRet (TClass::*Method)(TArgs...) const>
-  static TRet CallClassMemberConst(void* instance, TArgs... args) {
+  static TRet CallClassMemberConst(void* instance, TArgs&&... args) {
     auto const* class_instance =
         const_cast<TClass const*>(static_cast<TClass*>(instance));
     return (class_instance->*Method)(std::forward<TArgs>(args)...);

--- a/aether/events/event_handler.h
+++ b/aether/events/event_handler.h
@@ -18,7 +18,6 @@
 #define AETHER_EVENTS_EVENT_HANDLER_H_
 
 #include <utility>
-#include <variant>
 #include <functional>
 
 #include "aether/common.h"
@@ -43,8 +42,7 @@ class EventHandler<void(TArgs...)> {
   AE_CLASS_COPY_MOVE(EventHandler);
 
   constexpr void Invoke(TArgs&&... args) const {
-    std::visit([&](auto& callback) { callback(std::forward<TArgs>(args)...); },
-               callback_);
+    callback_(std::forward<TArgs>(args)...);
   }
 
   void set_alive(bool value) { is_alive_ = value; }
@@ -52,8 +50,7 @@ class EventHandler<void(TArgs...)> {
 
  private:
   bool is_alive_;
-  std::variant<Delegate<void(TArgs...)>, std::function<void(TArgs...)>>
-      callback_;
+  std::function<void(TArgs...)> callback_;
 };
 }  // namespace ae
 

--- a/aether/poller/freertos_poller.cpp
+++ b/aether/poller/freertos_poller.cpp
@@ -111,7 +111,7 @@ class FreertosPoller::PollWorker {
     assert(wake_up_pipe_[1] != -1);
 
     xTaskCreate(static_cast<void (*)(void *)>(&vTaskFunction), "Poller loop",
-                8192, static_cast<void *>(this), tskIDLE_PRIORITY,
+                4096, static_cast<void *>(this), tskIDLE_PRIORITY,
                 &myTaskHandle_);
     AE_TELE_DEBUG(PollerWorkerCreate, "Poll worker was created");
   }


### PR DESCRIPTION
 - Remove using of variant type in EventHandler couse its not give any benefits over std::function
   * In the future it would be better to replace both Delegate and std::function with something like static sized function
 - In Delegate remove extra Invoke function and change TArgs -> TArgs&& to caller functions
 - Change stack size for FreeRtosPoller 8192 -> 4096 