### PR TITLE
227 make a flag to highlight how strikt max packet size should be handled in streams

### DIFF
--- a/aether/CMakeLists.txt
+++ b/aether/CMakeLists.txt
@@ -118,7 +118,7 @@ list(APPEND transport_srcs
             "transport/low_level/sockets/lwip_tcp_socket.cpp"
             "transport/low_level/sockets/win_socket.cpp"
             "transport/low_level/sockets/win_tcp_socket.cpp"
-            "transport/low_level/tcp/socket_packet_send_action.cpp"
+            "transport/low_level/socket_packet_send_action.cpp"
             "transport/low_level/tcp/tcp.cpp"
             "transport/low_level/tcp/data_packet_collector.cpp"
 )

--- a/aether/ae_actions/telemetry.h
+++ b/aether/ae_actions/telemetry.h
@@ -52,7 +52,7 @@ class Telemetry : public Action<Telemetry> {
 
  private:
   void OnRequestTelemetry();
-  std::optional<Telemetric> CollectTelemetry();
+  std::optional<Telemetric> CollectTelemetry(StreamInfo const& stream_info);
 
   PtrView<Aether> aether_;
   ClientToServerStream* client_to_server_;

--- a/aether/channel.cpp
+++ b/aether/channel.cpp
@@ -40,7 +40,7 @@ void Channel::AddPingTime(Duration ping_time) {
 
 Duration Channel::expected_connection_time() const {
   assert(!channel_statistics->connection_time_statistics().empty());
-  return channel_statistics->connection_time_statistics().percentile<99>();
+  return 2 * channel_statistics->connection_time_statistics().percentile<99>();
 }
 
 Duration Channel::expected_ping_time() const {

--- a/aether/client_connections/client_to_server_stream.h
+++ b/aether/client_connections/client_to_server_stream.h
@@ -90,6 +90,8 @@ class ClientToServerStream final : public ByteIStream {
   Subscription connection_success_subscription_;
   Subscription connection_failed_subscription_;
   Subscription gate_update_subscription_;
+
+  ActionList<FailedStreamWriteAction> failed_actions_;
 };
 }  // namespace ae
 

--- a/aether/mstream_buffers.h
+++ b/aether/mstream_buffers.h
@@ -67,6 +67,33 @@ struct VectorReader {
   void result(ReadResult result) { result_ = result; }
 };
 
+/**
+ * \brief VectorWriter with limit in size
+ */
+template <typename SizeType = std::uint32_t>
+struct LimitVectorWriter {
+  using size_type = SizeType;
+
+  LimitVectorWriter(std::vector<std::uint8_t>& buffer, std::size_t l)
+      : data_buffer{buffer}, limit{l} {}
+
+  std::size_t write(void const* data, std::size_t size) {
+    if (end || ((data_buffer.size() + size) >= limit)) {
+      // end of writing
+      end = true;
+      return 0;
+    }
+    data_buffer.insert(data_buffer.end(),
+                       reinterpret_cast<std::uint8_t const*>(data),
+                       reinterpret_cast<std::uint8_t const*>(data) + size);
+    return size;
+  }
+
+  std::vector<std::uint8_t>& data_buffer;
+  std::size_t limit;
+  bool end = false;
+};
+
 template <typename SizeType = std::uint32_t>
 struct MemStreamReader {
   using size_type = SizeType;
@@ -112,7 +139,6 @@ struct MemStreamWriter {
 
   MemStreamBuf<> buffer;
 };
-
 }  // namespace ae
 
 #endif  // AETHER_MSTREAM_BUFFERS_H_ */

--- a/aether/stream_api/buffer_stream.cpp
+++ b/aether/stream_api/buffer_stream.cpp
@@ -119,6 +119,7 @@ void BufferStream::Unlink() {
 
   stream_info_.is_linked = false;
   stream_info_.is_writable = false;
+  stream_info_.strict_size_rules = false;
   stream_info_.max_element_size = 0;
   stream_info_.is_soft_writable = write_in_buffer_.size() < buffer_max_;
   stream_update_event_.Emit();
@@ -135,6 +136,7 @@ void BufferStream::UpdateGate() {
   auto out_info = out_->stream_info();
   if (last_out_stream_info_ != out_info) {
     stream_info_.is_linked = out_info.is_linked;
+    stream_info_.strict_size_rules = out_info.strict_size_rules;
     stream_info_.max_element_size = out_info.max_element_size;
     stream_info_.is_writable = out_info.is_writable;
 

--- a/aether/stream_api/istream.h
+++ b/aether/stream_api/istream.h
@@ -42,15 +42,19 @@ struct SelectOutDataEvent<U, std::enable_if_t<!std::is_void_v<U>>> {
 
 struct StreamInfo {
   std::size_t max_element_size;  //< Max size of element available to write,
-                                 // mostly the max packet size
-  bool is_linked;                //< is stream linked somewhere
-  bool is_writable;              //< is stream writeable */
-  bool is_soft_writable;         //< is stream soft writeable (!is_soft_writable
-                                 //&& !is_writable means write returns error)
+  // mostly the max packet size
+  bool strict_size_rules;  //< is true the packet size should be less than
+                           // max_element_size, otherwise it's just recommended
+                           // to be less or equal.
+  bool is_linked;          //< is stream linked somewhere
+  bool is_writable;        //< is stream writeable
+  bool is_soft_writable;   //< is stream soft writeable (!is_soft_writable
+                           //&& !is_writable means write returns error)
 };
 
 inline bool operator==(StreamInfo const& left, StreamInfo const& right) {
   return (left.max_element_size == right.max_element_size) &&
+         (left.strict_size_rules == right.strict_size_rules) &&
          (left.is_linked == right.is_linked) &&
          (left.is_soft_writable == right.is_soft_writable) &&
          (left.is_writable == right.is_writable);

--- a/aether/stream_api/safe_stream.cpp
+++ b/aether/stream_api/safe_stream.cpp
@@ -56,7 +56,7 @@ SafeStream::SafeStream(ActionContext action_context, SafeStreamConfig config)
     : safe_stream_action_{action_context, *this, config},
       safe_stream_api_{protocol_context_, safe_stream_action_},
       packet_send_actions_{action_context},
-      stream_info_{config.max_packet_size, false, false, false} {
+      stream_info_{config.max_packet_size, false, false, false, false} {
   safe_stream_action_.receive_event().Subscribe(
       *this, MethodPtr<&SafeStream::WriteOut>{});
 }
@@ -91,6 +91,7 @@ void SafeStream::OnStreamUpdate() {
   stream_info_.is_linked = out_info.is_linked;
   stream_info_.is_writable = out_info.is_writable;
   stream_info_.is_soft_writable = out_info.is_soft_writable;
+  stream_info_.strict_size_rules = false;  // packet's will be split in a chunks
 
   safe_stream_action_.set_max_data_size(out_info.max_element_size);
   stream_update_event_.Emit();

--- a/aether/stream_api/stream_write_action.cpp
+++ b/aether/stream_api/stream_write_action.cpp
@@ -18,6 +18,21 @@
 
 namespace ae {
 
+StreamWriteAction::StreamWriteAction(ActionContext action_context)
+    : Action{action_context}, state_{State::kQueued} {}
+
+StreamWriteAction::StreamWriteAction(StreamWriteAction&& other) noexcept
+    : Action{std::move(other)}, state_{std::move(other.state_)} {}
+
+StreamWriteAction& StreamWriteAction::operator=(
+    StreamWriteAction&& other) noexcept {
+  if (this != &other) {
+    Action::operator=(std::move(other));
+    state_ = std::move(other.state_);
+  }
+  return *this;
+}
+
 ActionResult StreamWriteAction::Update() {
   if (state_.changed()) {
     switch (state_.Acquire()) {
@@ -35,12 +50,8 @@ ActionResult StreamWriteAction::Update() {
   return {};
 }
 
-FailedStreamWriteAction::FailedStreamWriteAction() {
-  state_.Set(State::kFailed);
-}
-
 FailedStreamWriteAction::FailedStreamWriteAction(ActionContext action_context)
-    : StreamWriteAction(action_context) {
+    : StreamWriteAction{action_context} {
   state_.Set(State::kFailed);
 }
 

--- a/aether/stream_api/stream_write_action.h
+++ b/aether/stream_api/stream_write_action.h
@@ -34,7 +34,12 @@ class StreamWriteAction : public Action<StreamWriteAction> {
     kPanic,    // fatal unrecoverable error
   };
 
-  using Action::Action;
+  explicit StreamWriteAction(ActionContext action_context);
+  StreamWriteAction(StreamWriteAction const& other) = delete;
+  StreamWriteAction(StreamWriteAction&& other) noexcept;
+
+  StreamWriteAction& operator=(StreamWriteAction const& other) = delete;
+  StreamWriteAction& operator=(StreamWriteAction&& other) noexcept;
 
   virtual ActionResult Update();
 
@@ -52,7 +57,6 @@ class StreamWriteAction : public Action<StreamWriteAction> {
 class FailedStreamWriteAction final : public StreamWriteAction {
  public:
   using StreamWriteAction::StreamWriteAction;
-  FailedStreamWriteAction();
   explicit FailedStreamWriteAction(ActionContext action_context);
 
   ActionResult Update() override;

--- a/aether/stream_api/transport_write_stream.cpp
+++ b/aether/stream_api/transport_write_stream.cpp
@@ -18,9 +18,6 @@
 
 #include <utility>
 
-#include "aether/actions/action.h"
-#include "aether/stream_api/istream.h"
-
 #include "aether/tele/tele.h"
 
 namespace ae {
@@ -83,6 +80,8 @@ TransportWriteStream::TransportWriteStream(ActionContext action_context,
       connection_info.connection_state == ConnectionState::kConnected;
   stream_info_.is_writable = stream_info_.is_linked;
   stream_info_.is_soft_writable = stream_info_.is_linked;
+  // TODO:
+  stream_info_.is_soft_writable = stream_info_.is_linked;
 }
 
 TransportWriteStream::~TransportWriteStream() = default;
@@ -115,6 +114,7 @@ void TransportWriteStream::GateUpdate() {
   stream_info_.is_linked =
       connection_info.connection_state == ConnectionState::kConnected;
   stream_info_.is_writable = stream_info_.is_linked;
+  // TODO:
   stream_info_.is_soft_writable = stream_info_.is_linked;
   stream_update_event_.Emit();
 }

--- a/aether/stream_api/transport_write_stream.h
+++ b/aether/stream_api/transport_write_stream.h
@@ -18,11 +18,10 @@
 #define AETHER_STREAM_API_TRANSPORT_WRITE_STREAM_H_
 
 #include "aether/common.h"
-#include "aether/memory.h"
-#include "aether/actions/action_list.h"
-#include "aether/actions/action_context.h"
-#include "aether/transport/itransport.h"
 #include "aether/types/data_buffer.h"
+#include "aether/actions/action_list.h"
+#include "aether/transport/itransport.h"
+#include "aether/actions/action_context.h"
 
 #include "aether/stream_api/istream.h"
 

--- a/aether/stream_api/transport_write_stream.h
+++ b/aether/stream_api/transport_write_stream.h
@@ -54,6 +54,7 @@ class TransportWriteStream final : public ByteIStream {
  private:
   void GateUpdate();
   void ReceiveData(DataBuffer const& data, TimePoint current_time);
+  void SetStreamInfo(ConnectionInfo const& connection_info);
 
   ITransport* transport_;
 

--- a/aether/transport/actions/build_transport_action.h
+++ b/aether/transport/actions/build_transport_action.h
@@ -64,11 +64,11 @@ class BuildTransportAction final : public Action<BuildTransportAction> {
   std::optional<AsyncForLoop<std::unique_ptr<ITransport>>> builder_loop_;
   std::unique_ptr<ITransport> transport_;
   StateMachine<State> state_;
-  Subscription state_changed_;
-  Subscription builders_created_;
-  Subscription builders_failed_;
-  Subscription connected_;
-  Subscription connection_failed_;
+  Subscription state_changed_sub_;
+  Subscription builders_created_sub_;
+  Subscription builders_failed_sub_;
+  Subscription connected_sub_;
+  Subscription connection_failed_sub_;
 };
 
 }  // namespace ae

--- a/aether/transport/actions/packet_send_action.h
+++ b/aether/transport/actions/packet_send_action.h
@@ -39,11 +39,13 @@ class PacketSendAction : public Action<PacketSendAction> {
       : Action(action_context) {}
   PacketSendAction(PacketSendAction const& other) = delete;
   PacketSendAction(PacketSendAction&& other) noexcept
-      : Action(std::move(static_cast<Action&>(other))) {}
+      : Action(std::move(static_cast<Action&>(other))),
+        state_{std::move(other.state_)} {}
 
   PacketSendAction& operator=(PacketSendAction const& other) = delete;
   PacketSendAction& operator=(PacketSendAction&& other) noexcept {
     Action::operator=(std::move(static_cast<Action&>(other)));
+    state_ = std::move(other.state_);
     return *this;
   };
 

--- a/aether/transport/itransport.h
+++ b/aether/transport/itransport.h
@@ -20,7 +20,6 @@
 #include "aether/events/events.h"
 #include "aether/actions/action_view.h"
 
-#include "aether/types/address.h"
 #include "aether/types/data_buffer.h"
 #include "aether/transport/actions/packet_send_action.h"
 
@@ -32,10 +31,21 @@ enum class ConnectionState : std::uint8_t {
   kConnected,
 };
 
+enum class ConnectionType : std::uint8_t {
+  kConnectionLess,
+  kConnectionOriented,
+};
+
+enum class Reliability : std::uint8_t {
+  kReliable,
+  kUnreliable,
+};
+
 struct ConnectionInfo {
-  IpAddressPortProtocol destination;
   std::size_t max_packet_size;
   ConnectionState connection_state;
+  ConnectionType connection_type;
+  Reliability reliability;
 };
 
 class ITransport {

--- a/aether/transport/low_level/socket_packet_queue_manager.h
+++ b/aether/transport/low_level/socket_packet_queue_manager.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef AETHER_TRANSPORT_LOW_LEVEL_TCP_SOCKET_PACKET_QUEUE_MANAGER_H_
-#define AETHER_TRANSPORT_LOW_LEVEL_TCP_SOCKET_PACKET_QUEUE_MANAGER_H_
+#ifndef AETHER_TRANSPORT_LOW_LEVEL_SOCKET_PACKET_QUEUE_MANAGER_H_
+#define AETHER_TRANSPORT_LOW_LEVEL_SOCKET_PACKET_QUEUE_MANAGER_H_
 
 #include <queue>
 #include <mutex>
@@ -27,7 +27,7 @@
 #include "aether/events/multi_subscription.h"
 
 #include "aether/transport/actions/packet_send_action.h"
-#include "aether/transport/low_level/tcp/socket_packet_send_action.h"
+#include "aether/transport/low_level/socket_packet_send_action.h"
 
 namespace ae {
 template <typename TSocketPacketSendAction,
@@ -97,4 +97,4 @@ class SocketPacketQueueManager
 };
 }  // namespace ae
 
-#endif  // AETHER_TRANSPORT_LOW_LEVEL_TCP_SOCKET_PACKET_QUEUE_MANAGER_H_
+#endif  // AETHER_TRANSPORT_LOW_LEVEL_SOCKET_PACKET_QUEUE_MANAGER_H_

--- a/aether/transport/low_level/socket_packet_queue_manager.h
+++ b/aether/transport/low_level/socket_packet_queue_manager.h
@@ -53,8 +53,7 @@ class SocketPacketQueueManager
     auto lock = std::unique_lock{queue_lock_};
     auto view = actions_.Add(std::move(packet_send_action));
     queue_.emplace(view);
-    on_sent_subs_.Push(
-        view->ResultEvent().Subscribe([this](auto const&) { Send(); }));
+    on_sent_subs_.Push(view->FinishedEvent().Subscribe([this]() { Send(); }));
     BaseAction::Trigger();
     return view;
   }

--- a/aether/transport/low_level/socket_packet_send_action.cpp
+++ b/aether/transport/low_level/socket_packet_send_action.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "aether/transport/low_level/tcp/socket_packet_send_action.h"
+#include "aether/transport/low_level/socket_packet_send_action.h"
 
 namespace ae {
 ActionResult SocketPacketSendAction::Update() {

--- a/aether/transport/low_level/socket_packet_send_action.h
+++ b/aether/transport/low_level/socket_packet_send_action.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef AETHER_TRANSPORT_LOW_LEVEL_TCP_SOCKET_PACKET_SEND_ACTION_H_
-#define AETHER_TRANSPORT_LOW_LEVEL_TCP_SOCKET_PACKET_SEND_ACTION_H_
+#ifndef AETHER_TRANSPORT_LOW_LEVEL_SOCKET_PACKET_SEND_ACTION_H_
+#define AETHER_TRANSPORT_LOW_LEVEL_SOCKET_PACKET_SEND_ACTION_H_
 
 #include "aether/transport/actions/packet_send_action.h"
 
@@ -33,4 +33,4 @@ class SocketPacketSendAction : public PacketSendAction {
 };
 }  // namespace ae
 
-#endif  // AETHER_TRANSPORT_LOW_LEVEL_TCP_SOCKET_PACKET_SEND_ACTION_H_
+#endif  // AETHER_TRANSPORT_LOW_LEVEL_SOCKET_PACKET_SEND_ACTION_H_

--- a/aether/transport/low_level/sockets/isocket.h
+++ b/aether/transport/low_level/sockets/isocket.h
@@ -80,6 +80,11 @@ class ISocket {
    * \brief Get the maximum packet size (MTU)
    */
   virtual std::size_t GetMaxPacketSize() const = 0;
+
+  /**
+   * \brief Know if socket is valid.
+   */
+  virtual bool IsValid() const = 0;
 };
 }  // namespace ae
 

--- a/aether/transport/low_level/sockets/lwip_socket.cpp
+++ b/aether/transport/low_level/sockets/lwip_socket.cpp
@@ -182,5 +182,7 @@ std::optional<std::size_t> LwipSocket::Receive(Span<std::uint8_t> data) {
   return static_cast<std::size_t>(res);
 }
 
+bool LwipSocket::IsValid() const { return socket_ != kInvalidSocket; }
+
 }  // namespace ae
 #endif

--- a/aether/transport/low_level/sockets/lwip_socket.h
+++ b/aether/transport/low_level/sockets/lwip_socket.h
@@ -37,6 +37,7 @@ class LwipSocket : public ISocket {
   void Disconnect() override;
   std::optional<std::size_t> Send(Span<std::uint8_t> data) override;
   std::optional<std::size_t> Receive(Span<std::uint8_t> data) override;
+  bool IsValid() const override;
 
  private:
   int socket_;

--- a/aether/transport/low_level/sockets/unix_socket.cpp
+++ b/aether/transport/low_level/sockets/unix_socket.cpp
@@ -187,5 +187,7 @@ std::optional<std::size_t> UnixSocket::Receive(Span<std::uint8_t> data) {
   return static_cast<std::size_t>(res);
 }
 
+bool UnixSocket::IsValid() const { return socket_ != kInvalidSocket; }
+
 }  // namespace ae
 #endif

--- a/aether/transport/low_level/sockets/unix_socket.h
+++ b/aether/transport/low_level/sockets/unix_socket.h
@@ -41,6 +41,7 @@ class UnixSocket : public ISocket {
   void Disconnect() override;
   std::optional<std::size_t> Send(Span<std::uint8_t> data) override;
   std::optional<std::size_t> Receive(Span<std::uint8_t> data) override;
+  bool IsValid() const override;
 
  protected:
   int socket_;

--- a/aether/transport/low_level/sockets/win_socket.cpp
+++ b/aether/transport/low_level/sockets/win_socket.cpp
@@ -79,6 +79,8 @@ std::optional<std::size_t> WinSocket::Receive(Span<std::uint8_t> data) {
 
 std::size_t WinSocket::GetMaxPacketSize() const { return read_buffer_.size(); }
 
+bool WinSocket::IsValid() const { return socket_ != INVALID_SOCKET; }
+
 bool WinSocket::RequestRecv() {
   DWORD flags = 0;
   // request for read

--- a/aether/transport/low_level/sockets/win_socket.h
+++ b/aether/transport/low_level/sockets/win_socket.h
@@ -43,6 +43,7 @@ class WinSocket : public ISocket {
   std::optional<std::size_t> Send(Span<std::uint8_t> data) override;
   std::optional<std::size_t> Receive(Span<std::uint8_t> data) override;
   std::size_t GetMaxPacketSize() const override;
+  bool IsValid() const override;
 
  protected:
   bool RequestRecv();

--- a/aether/transport/low_level/tcp/tcp.cpp
+++ b/aether/transport/low_level/tcp/tcp.cpp
@@ -235,6 +235,8 @@ TcpTransport::TcpTransport(ActionContext action_context,
   AE_TELE_INFO(kPosixTcpTransport, "Created unix tcp transport to endpoint {}",
                endpoint_);
   connection_info_.connection_state = ConnectionState::kUndefined;
+  connection_info_.connection_type = ConnectionType::kConnectionOriented;
+  connection_info_.reliability = Reliability::kReliable;
 }
 
 TcpTransport::~TcpTransport() { Disconnect(); }

--- a/aether/transport/low_level/tcp/tcp.cpp
+++ b/aether/transport/low_level/tcp/tcp.cpp
@@ -27,8 +27,6 @@
 #  include "aether/transport/transport_tele.h"
 
 namespace ae {
-constexpr std::size_t kMtuSelected = 1500;
-
 TcpTransport::ConnectionAction::ConnectionAction(ActionContext action_context,
                                                  TcpTransport& transport)
     : Action{action_context},
@@ -178,7 +176,7 @@ TcpTransport::ReadAction::ReadAction(ActionContext action_context,
                                      TcpTransport& transport)
     : Action{action_context},
       transport_{&transport},
-      read_buffer_(kMtuSelected) {}
+      read_buffer_(transport_->socket_.GetMaxPacketSize()) {}
 
 ActionResult TcpTransport::ReadAction::Update() {
   if (read_event_.exchange(false)) {
@@ -291,7 +289,7 @@ ActionView<PacketSendAction> TcpTransport::Send(DataBuffer data,
 void TcpTransport::OnConnected() {
   connection_info_.connection_state = ConnectionState::kConnected;
   // 2 - for max packet size
-  connection_info_.max_packet_size = kMtuSelected - 2;
+  connection_info_.max_packet_size = socket_.GetMaxPacketSize() - 2;
 
   read_action_.emplace(action_context_, *this);
   read_action_error_sub_ =
@@ -360,6 +358,9 @@ void TcpTransport::Disconnect() {
   socket_error_subscription_.Reset();
 
   auto lock = std::lock_guard{socket_lock_};
+  if (!socket_.IsValid()) {
+    return;
+  }
   if (auto poller_ptr = poller_.Lock(); poller_ptr) {
     poller_ptr->Remove(static_cast<DescriptorType>(socket_));
   }

--- a/aether/transport/low_level/tcp/tcp.h
+++ b/aether/transport/low_level/tcp/tcp.h
@@ -34,8 +34,8 @@
 
 #  include "aether/transport/itransport.h"
 #  include "aether/transport/low_level/tcp/data_packet_collector.h"
-#  include "aether/transport/low_level/tcp/socket_packet_send_action.h"
-#  include "aether/transport/low_level/tcp/socket_packet_queue_manager.h"
+#  include "aether/transport/low_level/socket_packet_send_action.h"
+#  include "aether/transport/low_level/socket_packet_queue_manager.h"
 
 #  include "aether/transport/low_level/sockets/tcp_sockets_factory.h"
 

--- a/tests/test-stream/client-to-server-stream/test_client_to_server_stream.cpp
+++ b/tests/test-stream/client-to-server-stream/test_client_to_server_stream.cpp
@@ -74,8 +74,11 @@ class TestClientToServerStreamFixture {
 
   auto& MockTransport() {
     if (!mock_transport) {
-      mock_transport =
-          make_unique<ae::MockTransport>(*aether, ConnectionInfo{{}, 1500});
+      mock_transport = make_unique<ae::MockTransport>(
+          *aether, ConnectionInfo{1500,
+                                  {},
+                                  ConnectionType::kConnectionOriented,
+                                  Reliability::kReliable});
     }
     return *mock_transport;
   }


### PR DESCRIPTION
closes #227

 - Add a flag to highlight stream has strict packet size rule. This mean it's impossible to write data more than max element size into that stream.
 - Add `ConnectionType` and `Relibility` to `ITransport` `ConnectionInfo`. Stream's strict size rule are set based on this values.
 - Add reactions to data exceeded the max element size with strict size rules in stream.
 - Add cut sending telemetry to fit into max element size if strict size rules is applied.
