### PR TITLE
Drop invalid sync packets instead of asserting

### DIFF
--- a/aether/api_protocol/api_class_impl.h
+++ b/aether/api_protocol/api_class_impl.h
@@ -20,6 +20,7 @@
 #include "aether-miscpp/reflect/reflect.h"
 #include "aether/api_protocol/api_class.h"
 #include "aether/api_protocol/api_pack_parser.h"
+#include "aether/tele/tele.h"
 
 namespace ae {
 /**
@@ -245,7 +246,10 @@ class ApiClassImpl : public ApiClass {
   void LoadFactory(MessageId message_id, ApiParser& parser) {
     auto res = LoadFactoryImpl(static_cast<Api*>(this), message_id, parser);
     if (!res) {
-      assert(false && "Implementation not found");
+      AE_TELED_WARNING("Dropped packet: unknown API message id {}",
+                       static_cast<std::uint32_t>(message_id));
+      parser.Cancel();
+      return;
     }
   }
 };

--- a/aether/api_protocol/sub_api.h
+++ b/aether/api_protocol/sub_api.h
@@ -76,6 +76,9 @@ class SubApiImpl {
   template <typename TFunc = PassThrough>
   void Parse(TApi& api, TFunc pre_parse = {}) {
     auto&& mod_data = pre_parse(data_);
+    if (mod_data.empty()) {
+      return;
+    }
     ApiParser parser{api.protocol_context(), mod_data};
     parser.Parse(api);
   }

--- a/aether/crypto/hydrogen/hydro_sync_crypto_provider.cpp
+++ b/aether/crypto/hydrogen/hydro_sync_crypto_provider.cpp
@@ -24,6 +24,7 @@
 #  include <vector>
 
 #  include "aether/crypto/crypto_definitions.h"
+#  include "aether/tele/tele.h"
 
 namespace ae {
 namespace _internal {
@@ -49,6 +50,11 @@ inline std::vector<std::uint8_t> EncryptWithSymmetric(
 inline std::vector<std::uint8_t> DecryptWithSymmetric(
     HydrogenSecretBoxKey const& secret_key,
     std::vector<std::uint8_t> const& encrypted_data) {
+  if (encrypted_data.size() <=
+      sizeof(std::uint64_t) + hydro_secretbox_HEADERBYTES) {
+    return {};
+  }
+
   auto const* msg_id_ptr = encrypted_data.data();
   auto msg_id = *reinterpret_cast<std::uint64_t const*>(msg_id_ptr);
 
@@ -57,11 +63,13 @@ inline std::vector<std::uint8_t> DecryptWithSymmetric(
 
   auto const* encrypted_ptr = msg_id_ptr + sizeof(msg_id);
 
-  [[maybe_unused]] auto r =
-      hydro_secretbox_decrypt(decrypted_data.data(), encrypted_ptr,
-                              encrypted_data.size() - sizeof(msg_id), msg_id,
-                              HYDRO_CONTEXT, secret_key.key.data());
-  assert(r == 0);
+  auto r = hydro_secretbox_decrypt(
+      decrypted_data.data(), encrypted_ptr,
+      encrypted_data.size() - sizeof(msg_id), msg_id, HYDRO_CONTEXT,
+      secret_key.key.data());
+  if (r != 0) {
+    return {};
+  }
 
   return decrypted_data;
 }
@@ -93,7 +101,12 @@ DataBuffer HydroSyncDecryptProvider::Decrypt(DataBuffer const& data) {
   auto key = key_provider_->GetKey();
   assert(key.Index() == CryptoKeyType::kHydrogenSecretBox);
 
-  return _internal::DecryptWithSymmetric(key.Get<HydrogenSecretBoxKey>(), data);
+  auto decrypted =
+      _internal::DecryptWithSymmetric(key.Get<HydrogenSecretBoxKey>(), data);
+  if (decrypted.empty()) {
+    AE_TELED_WARNING("Dropped packet: sync decrypt failed");
+  }
+  return decrypted;
 }
 
 }  // namespace ae

--- a/aether/crypto/sodium/sodium_sync_crypto_provider.cpp
+++ b/aether/crypto/sodium/sodium_sync_crypto_provider.cpp
@@ -18,12 +18,13 @@
 
 #if AE_CRYPTO_SYNC == AE_CHACHA20_POLY1305
 
-#  include <vector>
+#  include <algorithm>
 #  include <cassert>
 #  include <utility>
-#  include <algorithm>
+#  include <vector>
 
 #  include "aether/crypto/crypto_nonce.h"
+#  include "aether/tele/tele.h"
 
 namespace ae {
 
@@ -57,7 +58,10 @@ inline DataBuffer EncryptWithSymmetric(
 inline DataBuffer DecryptWithSymmetric(
     SodiumChacha20Poly1305Key const& secret_key,
     DataBuffer const& encrypted_data) {
-  assert(encrypted_data.size() > kNonceSize);
+  if (encrypted_data.size() <=
+      kNonceSize + crypto_aead_chacha20poly1305_ABYTES) {
+    return {};
+  }
 
   auto nonce = CryptoNonce{};
   auto encrypted_data_size = encrypted_data.size() - nonce.value.size();
@@ -69,15 +73,18 @@ inline DataBuffer DecryptWithSymmetric(
 
   auto decrypted_data = std::vector<uint8_t>(
       encrypted_data_size - crypto_aead_chacha20poly1305_ABYTES);
-  unsigned long long decrypted_len;
+  unsigned long long decrypted_len{0};
 
-  [[maybe_unused]] auto r = crypto_aead_chacha20poly1305_decrypt(
+  auto r = crypto_aead_chacha20poly1305_decrypt(
       decrypted_data.data(), &decrypted_len, nullptr, encrypted_data.data(),
       encrypted_data_size, nullptr, 0, nonce.value.data(),
       secret_key.key.data());
 
-  assert(r == 0);
+  if (r != 0) {
+    return {};
+  }
 
+  decrypted_data.resize(static_cast<std::size_t>(decrypted_len));
   return decrypted_data;
 }
 }  // namespace _internal
@@ -106,8 +113,12 @@ DataBuffer SodiumSyncDecryptProvider::Decrypt(DataBuffer const& data) {
   auto key = key_provider_->GetKey();
   assert(key.Index() == CryptoKeyType::kSodiumChacha20Poly1305);
 
-  return _internal::DecryptWithSymmetric(key.Get<SodiumChacha20Poly1305Key>(),
-                                         data);
+  auto decrypted = _internal::DecryptWithSymmetric(
+      key.Get<SodiumChacha20Poly1305Key>(), data);
+  if (decrypted.empty()) {
+    AE_TELED_WARNING("Dropped packet: sync decrypt failed");
+  }
+  return decrypted;
 }
 
 }  // namespace ae

--- a/aether/work_cloud_api/client_api/client_api_unsafe.cpp
+++ b/aether/work_cloud_api/client_api/client_api_unsafe.cpp
@@ -29,6 +29,10 @@ ClientApiUnsafe::ClientApiUnsafe(ProtocolContext& protocol_context,
 void ClientApiUnsafe::SendSafeApiData(SubApiImpl<ClientApiSafe> sub_api) {
   sub_api.Parse(client_safe_api_, [this](auto const& data) {
     auto decrypted = Decrypt(data);
+    if (decrypted.empty()) {
+      AE_TELED_WARNING("Dropped packet: client safe api decrypt failed");
+      return decrypted;
+    }
     AE_TELED_DEBUG("Client api unsafe data {}", decrypted);
     return decrypted;
   });


### PR DESCRIPTION
## Summary

- Drop invalid sync packets instead of asserting on sync decrypt failures.
- Cancel API parsing and drop the packet when an unknown API message id is received.
- Skip parsing empty decrypted sub-API payloads.
- Log dropped invalid/stale packets through `AE_TELED_WARNING`.

## Context

This prevents crashes on stale/corrupt packets observed after client restart/close sequences, where old packets can arrive with a different crypto/session state.

## Validation

Manually validated through the Support Chat restart/close scenario:

1. Admin + Client online delivery in both directions.
2. Close Client while Admin stays open.
3. Close both, then open Client first and Admin second.
4. No assert crash on decrypt/API parse failure.
5. Messages continue to deliver in both directions.