### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,29 @@
 ## Operational Rules
 
 - Do not analyze logs until everything is working fine.
+
+## Cursor Cloud specific instructions
+
+These notes complement the `Build & Testing` and `Smoke test` sections above; they capture non-obvious, environment-specific gotchas for the Cursor Cloud VM. Standard build/test/smoke commands are already documented above.
+
+### Toolchain
+
+- The concrete `<build-dir>` used in the cloud VM is `build-clang`, built with `clang++` + Ninja.
+- `clang` selects the gcc-14 toolchain for its C++ runtime, so `libstdc++-14-dev` must be installed (the update script installs it together with `ninja-build`). Without it, even the CMake compiler check fails with `cannot find -lstdc++`. `cmake`, `clang-18`, and `g++-13` are already present in the base image.
+- Configure command that works here (the `-C .github/workflows/linux_initial_cache.txt` seed pre-answers c-ares feature probes):
+  `cmake -B build-clang -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -C .github/workflows/linux_initial_cache.txt -S .`
+
+### Dependencies (CPM)
+
+- There is no vendored dependency tree: all third-party libs (libsodium, libhydrogen, libbcrypt, c-ares, etl, stdexec, numeric, aether-miscpp, gcem, ini.h) are fetched from GitHub at **cmake configure time** by CPM. Configuring therefore needs network + git.
+- Export `CPM_SOURCE_CACHE=$HOME/.cache/CPM` before configuring so re-configures reuse the download cache instead of re-cloning into the build dir. This is optional but much faster.
+
+### Lint
+
+- The library builds with `-Werror -Wall -Wextra -Wconversion`, so a clean build is the primary lint gate.
+- The additional static-analysis lint is cppcheck 2.21.0, run exactly as in `.github/workflows/ci-cppcheck.yml` (build cppcheck from source, configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, then run cppcheck against `compile_commands.json`). Any findings live only in third-party CPM sources; the project's own `aether/`, `examples/`, and `tools/` code is clean.
+
+### Smoke test caveat (important)
+
+- `aether-client-cpp-cloud` reliably completes the **registration** phase from the cloud VM: both clients A and B register with the registration cloud (`Registration confirmed` / `Client registered`) and a persistent `state/` dir is written.
+- The subsequent **peer-to-peer messaging** phase does not complete here: the assigned work-cloud relay servers (e.g. `34.60.244.148:9021`) accept TCP but never answer the UDP ping/relay traffic, so `received_count` stays `0`. The binary then crashes on that connection-failure path. This is an external work-cloud reachability limitation (not a build/env problem), so treat successful registration + `state/` creation as the working end-to-end signal in this environment rather than a clean exit 0.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the development environment for `aether-client-cpp` on the Cursor Cloud VM, and documents the non-obvious setup steps for future agents.

The only code change is documentation: a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. No source code was modified. The VM update script installs `ninja-build` and `libstdc++-14-dev`.

## What was validated

| Step | Command | Result |
|------|---------|--------|
| Configure | `cmake -B build-clang -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -C .github/workflows/linux_initial_cache.txt -S .` | OK |
| Build | `cmake --build build-clang --parallel 4` | 568/568 targets built |
| Lint (compiler) | build with `-Werror -Wall -Wextra -Wconversion` | clean |
| Lint (cppcheck 2.21.0) | as in `ci-cppcheck.yml` | project code clean (findings only in third-party CPM deps) |
| Tests | `ctest . -j -E "((sodium)|(hydro)|(bcrypt)).*" --output-on-failure` | 22/22 passed |
| Run (smoke) | `./aether-client-cpp-cloud` | both clients register with the cloud; `state/` persisted |

## Notes

- Dependencies are fetched from GitHub by CPM at cmake configure time (no vendored tree). `clang` selects the gcc-14 runtime, so `libstdc++-14-dev` is required.
- The cloud smoke test reliably completes the registration phase, but the peer-to-peer messaging phase does not complete from the VM: the assigned work-cloud relay servers accept TCP but do not answer UDP relay traffic (`received_count=0`), and the binary crashes on that failure path. This is an external work-cloud reachability limitation, documented in `AGENTS.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7aa2514-7c35-4fb0-849d-1c9c26d4e670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7aa2514-7c35-4fb0-849d-1c9c26d4e670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

